### PR TITLE
Move serde to a feature flag separate from discovery.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,15 +77,13 @@ docs = []
 incoming = []
 client = ["incoming", "dep:socket2", "dep:thiserror"]
 server = ["incoming", "dep:ouroboros", "dep:thiserror"]
+serde = ["dep:serde", "camino/serde1", "dep:humantime-serde"]
 discovery = [
     "server",
     "client",
     "pidfile",
     "stream",
-    "dep:humantime-serde",
     "dep:dashmap",
-    "dep:serde",
-    "camino/serde1",
 ]
 pidfile = ["dep:libc"]
 sni = []
@@ -168,7 +166,7 @@ required-features = ["client", "server", "tls", "tls-ring"]
 ignored = ["humantime-serde"]
 
 [package.metadata.cargo-udeps.ignore]
-normal = ["rustls-native-certs", "rustls", "tokio-rustls"]
+normal = ["rustls-native-certs", "rustls", "tokio-rustls", "humantime-serde"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/justfile
+++ b/justfile
@@ -13,6 +13,7 @@ all: fmt check-all deny clippy examples docs test machete udeps msrv
 
 # Check for unused dependencies
 udeps:
+    cargo +{{nightly}} udeps --all-features
     cargo +{{nightly}} hack udeps --each-feature
 
 # Use machete to check for unused dependencies

--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -152,8 +152,9 @@ impl std::error::Error for BindError {
 }
 
 /// Service discovery mechanism for services registered.
-#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "lowercase")]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
 pub enum ServiceDiscovery {
     /// Discover services in the same process, using an in-memory store and transport.
     #[default]
@@ -167,21 +168,22 @@ pub enum ServiceDiscovery {
 }
 
 /// Configuration for the service registry.
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
-#[serde(default)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct RegistryConfig {
     /// Service discovery mechanism.
     pub service_discovery: ServiceDiscovery,
 
     /// Connection timeout when finding a service.
-    #[serde(with = "humantime_serde")]
+    #[cfg_attr(feature = "serde", serde(with = "humantime_serde"))]
     pub connect_timeout: Option<std::time::Duration>,
 
     /// Buffer size for in-memory transports.
     pub buffer_size: usize,
 
     /// Proxy service timeout
-    #[serde(with = "humantime_serde")]
+    #[cfg_attr(feature = "serde", serde(with = "humantime_serde"))]
     pub proxy_timeout: std::time::Duration,
 
     /// Proxy concurrency limit


### PR DESCRIPTION
It isn't necessary to have serde in the discovery module, so we can
move it to a feature flag.

In the future, there are things outside of discovery which we might
want to put serde on, so this is a good first step.
