### PR TITLE
Client as tower::Service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,6 +714,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "webpki-roots",
@@ -733,6 +734,16 @@ checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "iri-string"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21859b667d66a4c1dacd9df0863b3efb65785474255face87f5bca39dd8407c0"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -1534,6 +1545,26 @@ dependencies = [
  "pin-project",
  "pin-project-lite",
  "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,12 @@ version = "0.4"
 features = ["make", "util"]
 default-features = false
 
+[dependencies.tower-http]
+version = "0.5.2"
+features = ["follow-redirect", "set-header", "trace"]
+default-features = false
+optional = true
+
 [dev-dependencies]
 clap = { version = "4.5.7" }
 color-eyre = "0.6"
@@ -73,7 +79,7 @@ webpki-roots.version = "0.26"
 
 [features]
 axum = ["dep:axum"]
-client = ["incoming", "dep:socket2", "dep:thiserror"]
+client = ["incoming", "dep:socket2", "dep:thiserror", "dep:tower-http"]
 default = ["client", "server", "discovery", "stream"]
 discovery = ["server", "client", "pidfile", "stream", "dep:dashmap"]
 docs = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ client = [
     "dep:thiserror",
     "dep:tower-http",
     "tower/timeout",
+    "tower/retry",
 ]
 default = ["client", "server", "discovery", "stream"]
 discovery = ["server", "client", "pidfile", "stream", "dep:dashmap"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,13 @@ webpki-roots.version = "0.26"
 
 [features]
 axum = ["dep:axum"]
-client = ["incoming", "dep:socket2", "dep:thiserror", "dep:tower-http"]
+client = [
+    "incoming",
+    "dep:socket2",
+    "dep:thiserror",
+    "dep:tower-http",
+    "tower/timeout",
+]
 default = ["client", "server", "discovery", "stream"]
 discovery = ["server", "client", "pidfile", "stream", "dep:dashmap"]
 docs = []

--- a/examples/client/google.rs
+++ b/examples/client/google.rs
@@ -8,12 +8,14 @@ use hyperdriver::client::Client;
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     tracing_subscriber::fmt::init();
 
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     let client = Client::build_tcp_http().build();
 
     let uri: Uri = "https://www.google.com".parse()?;
     let res = client.get(uri.clone()).await?;
 
-    println!("1 Response: {} - {:?}", res.status(), res.version());
+    println!("1st Response: {} - {:?}", res.status(), res.version());
 
     for (name, value) in res.headers() {
         if let Ok(value) = value.to_str() {
@@ -22,7 +24,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
     }
 
     let r2 = client.get(uri.clone()).await?;
-    println!("2 Response: {}", r2.status());
+    println!("2nd Response: {}", r2.status());
 
     let mut body = res.into_body();
 
@@ -36,7 +38,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
     drop(r2);
 
     let r3 = client.get(uri).await?;
-    println!("3 Response: {}", r3.status());
+    println!("3rd Response: {}", r3.status());
 
     Ok(())
 }

--- a/examples/client/google.rs
+++ b/examples/client/google.rs
@@ -5,7 +5,7 @@ use http_body_util::BodyExt as _;
 use hyperdriver::client::Client;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     tracing_subscriber::fmt::init();
 
     let client = Client::build_tcp_http().build();

--- a/examples/client/google.rs
+++ b/examples/client/google.rs
@@ -8,7 +8,7 @@ use hyperdriver::client::Client;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let client = Client::new_tcp_http();
+    let mut client = Client::new_tcp_http();
 
     let uri: Uri = "https://www.google.com".parse()?;
     let res = client.get(uri.clone()).await?;

--- a/examples/client/google.rs
+++ b/examples/client/google.rs
@@ -8,7 +8,7 @@ use hyperdriver::client::Client;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let mut client = Client::new_tcp_http();
+    let client = Client::build_tcp_http().build();
 
     let uri: Uri = "https://www.google.com".parse()?;
     let res = client.get(uri.clone()).await?;

--- a/examples/client/hello.rs
+++ b/examples/client/hello.rs
@@ -42,7 +42,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .get_matches();
 
-    let mut client = Client::builder();
+    let mut client = Client::builder()
+        .with_tcp(Default::default())
+        .with_auto_http();
 
     if let Some(tls_root) = args.get_one::<String>("tls-root") {
         println!("Using TLS root: {}", tls_root);
@@ -92,7 +94,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 async fn send(
-    mut client: Client,
+    client: Client,
     uri: Uri,
     version: http::Version,
     done: tokio::sync::mpsc::Sender<()>,

--- a/examples/client/hello.rs
+++ b/examples/client/hello.rs
@@ -92,7 +92,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 async fn send(
-    client: Client,
+    mut client: Client,
     uri: Uri,
     version: http::Version,
     done: tokio::sync::mpsc::Sender<()>,

--- a/examples/client/hello.rs
+++ b/examples/client/hello.rs
@@ -12,6 +12,8 @@ use tokio::io::AsyncWriteExt;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     let args = clap::Command::new("patron")
         .version(env!("CARGO_PKG_VERSION"))
         .about("HTTP/2 client")

--- a/examples/client/httpbin.rs
+++ b/examples/client/httpbin.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
         ])
         .get_matches();
 
-    let client = Client::new_tcp_http();
+    let mut client = Client::new_tcp_http();
 
     let uri: Uri = "https://www.httpbin.org/".parse()?;
 

--- a/examples/client/httpbin.rs
+++ b/examples/client/httpbin.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
         ])
         .get_matches();
 
-    let mut client = Client::new_tcp_http();
+    let client = Client::build_tcp_http().build();
 
     let uri: Uri = "https://www.httpbin.org/".parse()?;
 

--- a/examples/client/httpbin.rs
+++ b/examples/client/httpbin.rs
@@ -13,6 +13,8 @@ use tokio::io::AsyncWriteExt as _;
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     tracing_subscriber::fmt::init();
 
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     let args = clap::Command::new("httpbin")
         .args([
             arg!(-X --method [METHOD] "HTTP method to use").default_value("GET"),

--- a/justfile
+++ b/justfile
@@ -64,6 +64,11 @@ test:
 coverage:
     cargo +{{rust}} tarpaulin -o html --features axum,sni,tls,tls-ring,mocks
 
+alias timing := timings
+# Compile with timing checks
+timings:
+    cargo +{{rust}} build --features  axum,sni,tls,tls-ring,mocks --timings
+
 # Run deny checks
 deny:
     cargo +{{rust}} deny check

--- a/justfile
+++ b/justfile
@@ -11,7 +11,9 @@ all: fmt check-all deny clippy examples docs test machete udeps msrv
 
 # Check for unused dependencies
 udeps:
-    cargo +{{nightly}} udeps --all-features
+    #!/usr/bin/env sh
+    export CARGO_TARGET_DIR="target/hack/"
+    cargo +{{nightly}} udeps  --all-features
     cargo +{{nightly}} hack udeps --each-feature
 
 # Use machete to check for unused dependencies
@@ -26,8 +28,8 @@ check:
 # Check compilation across all features
 check-all:
     cargo +{{rust}} check --all-targets --all-features
-    cargo +{{rust}} hack check --no-private --each-feature --no-dev-deps
-    cargo +{{rust}} hack check --no-private --feature-powerset --no-dev-deps --skip docs,axum,sni,pidfile,tls-ring,tls-aws-lc
+    cargo +{{rust}} hack check --target-dir target/hack/ --no-private --each-feature --no-dev-deps
+    cargo +{{rust}} hack check --target-dir target/hack/ --no-private --feature-powerset --no-dev-deps --skip docs,axum,sni,pidfile,tls-ring,tls-aws-lc
 
 # Run clippy
 clippy:
@@ -48,8 +50,8 @@ read: docs
 
 # Check support for MSRV
 msrv:
-    cargo +{{msrv}} check --all-targets --all-features
-    cargo +{{msrv}} doc --all-features --no-deps
+    cargo +{{msrv}} check --target-dir target/msrv/ --all-targets --all-features
+    cargo +{{msrv}} doc --target-dir target/msrv/ --all-features --no-deps
 
 
 alias t := test

--- a/justfile
+++ b/justfile
@@ -40,6 +40,7 @@ examples:
     cargo +{{rust}} check --examples --all-features
 
 alias d := docs
+alias doc := docs
 # Build documentation
 docs:
     cargo +{{rust}} doc --all-features --no-deps

--- a/src/body/mod.rs
+++ b/src/body/mod.rs
@@ -62,6 +62,27 @@ impl Body {
         }
     }
 
+    /// Try to clone this body.
+    pub fn try_clone(&self) -> Option<Self> {
+        match &self.inner {
+            InnerBody::Boxed(_) => None,
+            InnerBody::Full(body) => Some(Self {
+                inner: InnerBody::Full(body.clone()),
+            }),
+            InnerBody::Empty => Some(Self {
+                inner: InnerBody::Empty,
+            }),
+            InnerBody::Http(_) => None,
+            InnerBody::HttpSync(_) => None,
+
+            #[cfg(feature = "incoming")]
+            InnerBody::Incoming(_) => None,
+
+            #[cfg(feature = "axum")]
+            InnerBody::AxumBody(_) => None,
+        }
+    }
+
     /// Convert this body into a boxed body.
     pub fn as_boxed(self) -> UnsyncBoxBody<Bytes, BoxError> {
         match self.inner {

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -1,56 +1,134 @@
 #[cfg(feature = "tls")]
 use std::sync::Arc;
 
+use http::HeaderValue;
 #[cfg(feature = "tls")]
 use rustls::ClientConfig;
+use tower::ServiceBuilder;
+use tower_http::follow_redirect::FollowRedirectLayer;
+use tower_http::set_header::SetRequestHeaderLayer;
 
-use super::conn::transport::TransportExt as _;
+use super::conn::protocol::auto;
+use super::conn::transport::tcp::TcpTransportConfig;
+use super::conn::transport::TransportExt;
+use super::conn::Connection;
+use super::conn::Protocol;
+use super::conn::Transport;
+use super::pool::PoolableConnection;
 use super::ClientService;
-use super::ClientTlsTcpService;
+use crate::client::conn::connection::ConnectionError;
 #[cfg(feature = "tls")]
 use crate::client::default_tls_config;
 use crate::client::{conn::protocol::auto::HttpConnectionBuilder, Client};
+use crate::info::HasConnectionInfo;
+use crate::service::SharedService;
+
+pub trait BuildProtocol<IO>
+where
+    IO: HasConnectionInfo,
+{
+    type Target: Protocol<IO>;
+    fn build(self) -> Self::Target;
+}
+
+impl<P, IO> BuildProtocol<IO> for P
+where
+    P: Protocol<IO>,
+    IO: HasConnectionInfo,
+{
+    type Target = P;
+    fn build(self) -> Self::Target {
+        self
+    }
+}
+
+pub trait BuildTransport {
+    type Target: Transport;
+    fn build(self) -> Self::Target;
+}
+
+impl<T> BuildTransport for T
+where
+    T: Transport,
+{
+    type Target = T;
+    fn build(self) -> Self::Target {
+        self
+    }
+}
 
 /// A builder for a client.
 #[derive(Debug)]
-pub struct Builder {
-    tcp: crate::client::conn::transport::tcp::TcpTransportConfig,
+pub struct Builder<T, P> {
+    transport: T,
+    protocol: P,
+    user_agent: Option<String>,
     #[cfg(feature = "tls")]
     tls: Option<ClientConfig>,
     pool: Option<crate::client::pool::Config>,
-    conn: HttpConnectionBuilder,
 }
 
-impl Default for Builder {
-    fn default() -> Self {
+impl Builder<(), ()> {
+    /// Create a new, empty builder
+    pub fn new() -> Self {
         Self {
-            tcp: Default::default(),
+            transport: (),
+            protocol: (),
+            user_agent: None,
             #[cfg(feature = "tls")]
-            tls: Some(default_tls_config()),
-            pool: Some(Default::default()),
-            conn: Default::default(),
+            tls: None,
+            pool: None,
         }
     }
 }
 
-impl Builder {
+impl Default for Builder<TcpTransportConfig, HttpConnectionBuilder> {
+    fn default() -> Self {
+        Self {
+            transport: Default::default(),
+            protocol: Default::default(),
+            user_agent: None,
+            #[cfg(feature = "tls")]
+            tls: Some(default_tls_config()),
+            pool: Some(Default::default()),
+        }
+    }
+}
+
+impl<T, P> Builder<T, P> {
     /// Use the provided TCP configuration.
-    pub fn with_tcp(
-        mut self,
-        config: crate::client::conn::transport::tcp::TcpTransportConfig,
-    ) -> Self {
-        self.tcp = config;
-        self
+    pub fn with_tcp(self, config: TcpTransportConfig) -> Builder<TcpTransportConfig, P> {
+        Builder {
+            transport: config,
+            protocol: self.protocol,
+            user_agent: self.user_agent,
+            #[cfg(feature = "tls")]
+            tls: self.tls,
+            pool: self.pool,
+        }
     }
 
-    /// TCP configuration.
-    pub fn tcp(&mut self) -> &mut crate::client::conn::transport::tcp::TcpTransportConfig {
-        &mut self.tcp
+    /// Provide a custom transport
+    pub fn with_transport<T2>(self, transport: T2) -> Builder<T2, P> {
+        Builder {
+            transport,
+            protocol: self.protocol,
+            user_agent: self.user_agent,
+            #[cfg(feature = "tls")]
+            tls: self.tls,
+            pool: self.pool,
+        }
     }
 }
 
 #[cfg(feature = "tls")]
-impl Builder {
+impl<T, P> Builder<T, P> {
+    /// Disable TLS
+    pub fn without_tls(mut self) -> Self {
+        self.tls = None;
+        self
+    }
+
     /// Use the provided TLS configuration.
     pub fn with_tls(mut self, config: ClientConfig) -> Self {
         self.tls = Some(config);
@@ -69,15 +147,29 @@ impl Builder {
     }
 }
 
-impl Builder {
+#[cfg(not(feature = "tls"))]
+impl<T, P> Builder<T, P> {
+    /// Disable TLS
+    pub fn without_tls(self) -> Self {
+        self
+    }
+}
+
+impl<T, P> Builder<T, P> {
     /// Connection pool configuration.
-    pub fn pool(&mut self) -> &mut Option<crate::client::pool::Config> {
-        &mut self.pool
+    pub fn pool(&mut self) -> Option<&mut crate::client::pool::Config> {
+        self.pool.as_mut()
     }
 
     /// Use the provided connection pool configuration.
     pub fn with_pool(mut self, pool: crate::client::pool::Config) -> Self {
         self.pool = Some(pool);
+        self
+    }
+
+    /// Configure the default pool settings
+    pub fn with_default_pool(mut self) -> Self {
+        self.pool = Some(Default::default());
         self
     }
 
@@ -88,86 +180,112 @@ impl Builder {
     }
 }
 
-impl Builder {
+impl<T, P> Builder<T, P> {
+    /// Use the auto-HTTP Protocol
+    pub fn with_auto_http(self) -> Builder<T, auto::HttpConnectionBuilder> {
+        Builder {
+            transport: self.transport,
+            protocol: auto::HttpConnectionBuilder::default(),
+            user_agent: self.user_agent,
+            #[cfg(feature = "tls")]
+            tls: self.tls,
+            pool: self.pool,
+        }
+    }
+
     /// Use the provided HTTP connection configuration.
-    pub fn with_conn(
-        mut self,
-        conn: crate::client::conn::protocol::auto::HttpConnectionBuilder,
-    ) -> Self {
-        self.conn = conn;
-        self
+    pub fn with_protocol<P2>(self, protocol: P2) -> Builder<T, P2> {
+        Builder {
+            transport: self.transport,
+            protocol,
+            user_agent: self.user_agent,
+            #[cfg(feature = "tls")]
+            tls: self.tls,
+            pool: self.pool,
+        }
     }
 
     /// HTTP connection configuration.
-    pub fn conn(&mut self) -> &mut crate::client::conn::protocol::auto::HttpConnectionBuilder {
-        &mut self.conn
+    pub fn protocol(&mut self) -> &mut P {
+        &mut self.protocol
     }
 }
 
-impl Builder {
+impl<T, P> Builder<T, P>
+where
+    T: BuildTransport,
+    <T as BuildTransport>::Target: Transport + Clone + Send + Sync + 'static,
+    <<T as BuildTransport>::Target as Transport>::IO:
+        tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+    <<<T as BuildTransport>::Target as Transport>::IO as HasConnectionInfo>::Addr:
+        Unpin + Clone + Send,
+    P: BuildProtocol<super::conn::stream::Stream<<<T as BuildTransport>::Target as Transport>::IO>>,
+    <P as BuildProtocol<
+        super::conn::stream::Stream<<<T as BuildTransport>::Target as Transport>::IO>,
+    >>::Target: Protocol<
+            super::conn::stream::Stream<<<T as BuildTransport>::Target as Transport>::IO>,
+            Error = ConnectionError,
+        > + Clone
+        + Send
+        + Sync
+        + 'static,
+    <<P as BuildProtocol<
+        super::conn::stream::Stream<<<T as BuildTransport>::Target as Transport>::IO>,
+    >>::Target as Protocol<
+        super::conn::stream::Stream<<<T as BuildTransport>::Target as Transport>::IO>,
+    >>::Connection: PoolableConnection,
+    crate::Body: From<
+        <<<P as BuildProtocol<
+            super::conn::stream::Stream<<<T as BuildTransport>::Target as Transport>::IO>,
+        >>::Target as Protocol<
+            super::conn::stream::Stream<<<T as BuildTransport>::Target as Transport>::IO>,
+        >>::Connection as Connection>::ResBody,
+    >,
+{
     /// Build the client.
-    pub fn build(self) -> Client<ClientTlsTcpService> {
-        Client {
-            service: ClientService {
-                #[cfg(feature = "tls")]
-                transport: crate::client::conn::transport::tcp::TcpTransport::builder()
-                    .with_config(self.tcp)
-                    .with_gai_resolver()
-                    .build()
-                    .with_optional_tls(self.tls.map(Arc::new)),
+    pub fn build(self) -> Client {
+        let user_agent = if let Some(ua) = self.user_agent {
+            HeaderValue::from_str(&ua).expect("user-agent should be a valid http header")
+        } else {
+            HeaderValue::from_static(concat!(
+                env!("CARGO_PKG_NAME"),
+                "/",
+                env!("CARGO_PKG_VERSION")
+            ))
+        };
 
-                #[cfg(not(feature = "tls"))]
-                transport: crate::client::conn::transport::tcp::TcpTransport::builder()
-                    .with_config(self.tcp)
-                    .with_gai_resolver()
-                    .build()
-                    .without_tls(),
+        #[cfg(feature = "tls")]
+        let transport = self
+            .transport
+            .build()
+            .with_optional_tls(self.tls.map(Arc::new));
+        #[cfg(not(feature = "tls"))]
+        let transport = self.transport.build().without_tls();
 
-                protocol: HttpConnectionBuilder::default(),
-                pool: self.pool.map(crate::client::pool::Pool::new),
-
+        let service = ServiceBuilder::new()
+            .layer(SharedService::layer())
+            .layer(SetRequestHeaderLayer::if_not_present(
+                http::header::USER_AGENT,
+                user_agent,
+            ))
+            .layer(FollowRedirectLayer::new())
+            .service(ClientService {
+                transport,
+                protocol: self.protocol.build(),
+                pool: self.pool.map(super::pool::Pool::new),
                 _body: std::marker::PhantomData,
-            },
-        }
+            });
+
+        Client::new_from_service(service)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::Builder;
 
     #[test]
-    fn test_builder() {
-        let client = Builder::default().build();
-        assert!(client.service.pool.is_some());
-    }
-
-    #[test]
-    fn test_builder_tcp() {
-        let mut builder = Builder::default();
-        builder.tcp().nodelay = true;
-
-        let client = builder.build();
-        assert!(client.service.transport.inner().config().nodelay)
-    }
-
-    #[cfg(feature = "tls")]
-    #[test]
-    fn test_builder_tls() {
-        let mut builder = Builder::default();
-        let mut tls = super::default_tls_config();
-        tls.alpn_protocols.push(b"a1".to_vec());
-        builder = builder.with_tls(tls);
-
-        let client = builder.build();
-        assert_eq!(
-            client
-                .service
-                .transport
-                .tls_config()
-                .unwrap()
-                .alpn_protocols,
-            vec![b"h2".to_vec(), b"http/1.1".to_vec(), b"a1".to_vec()]
-        );
+    fn build_default_compiles() {
+        let _ = Builder::default().build();
     }
 }

--- a/src/client/conn/mod.rs
+++ b/src/client/conn/mod.rs
@@ -1,7 +1,7 @@
 //! Client connection types.
 //!
-//! A client connection is composed of a transport, a protocol, and a connection, which each serve a
-//! different purpose in the client connection lifecycle.
+//! A client connection is composed of a transport, which produces a stream, and a protocol, which produces
+//! a connection, which each serve a different purpose in the client connection lifecycle.
 //!
 //! ## Transport
 //!

--- a/src/client/conn/transport/tcp.rs
+++ b/src/client/conn/transport/tcp.rs
@@ -7,7 +7,7 @@
 //! Normally, you will not need to use this module directly. Instead, you can use the [`Client`][crate::client::Client]
 //! type from the [`client`][crate::client] module, which uses the [`TcpTransport`] internally by default.
 //!
-//! See [`Client::new_http_tcp`][crate::client::Client::new_tcp_http] for the default constructor which uses the TCP transport.
+//! See [`Client::build_tcp_http`][crate::client::Client::build_tcp_http] for the default constructor which uses the TCP transport.
 
 use std::fmt;
 use std::future::Future;
@@ -28,6 +28,7 @@ use tower::ServiceExt as _;
 use tracing::{trace, warn, Instrument};
 
 use super::TransportStream;
+use crate::client::builder::BuildTransport;
 use crate::client::conn::dns::{GaiResolver, IpVersion, SocketAddrs};
 use crate::happy_eyeballs::{EyeballSet, HappyEyeballsError};
 
@@ -445,6 +446,17 @@ impl Default for TcpTransportConfig {
             send_buffer_size: None,
             recv_buffer_size: None,
         }
+    }
+}
+
+impl BuildTransport for TcpTransportConfig {
+    type Target = TcpTransport;
+
+    fn build(self) -> Self::Target {
+        TcpTransport::builder()
+            .with_config(self)
+            .with_gai_resolver()
+            .build()
     }
 }
 

--- a/src/client/conn/transport/tls.rs
+++ b/src/client/conn/transport/tls.rs
@@ -167,8 +167,8 @@ pub(in crate::client::conn::transport) mod future {
                     } => match future.poll(cx) {
                         Poll::Ready(Ok(stream)) => {
                             let stream = stream.into_inner();
+                            tracing::trace!(domain=%domain, "Transport connected. TLS handshake starting");
                             let stream = ClientStream::new(stream).tls(domain, config.clone());
-                            tracing::trace!("Transport connected. TLS handshake starting");
                             this.state.set(State::Handshake { stream });
                         }
                         Poll::Ready(Err(e)) => {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,41 +1,25 @@
 //! HTTP client library for Rust, built on top of [hyper].
 
 use std::fmt;
-use std::future::poll_fn;
-use std::future::Future;
-use std::task::Poll;
+use std::sync::Arc;
 
-use self::conn::Protocol;
-use self::conn::Transport;
-use futures_util::future::BoxFuture;
-use futures_util::FutureExt;
-use http::uri::Port;
-use http::uri::Scheme;
-use http::HeaderValue;
-use http::Uri;
-use http::Version;
 use thiserror::Error;
 use tower::util::Oneshot;
 use tower::ServiceExt;
-use tracing::warn;
 
+use self::conn::protocol::auto;
+use self::conn::transport::tcp::TcpTransportConfig;
+pub use self::service::ClientService;
 use crate::client::conn::connection::ConnectionError;
 use crate::client::conn::protocol::auto::HttpConnectionBuilder;
-use crate::client::conn::protocol::HttpProtocol;
 use crate::client::conn::transport::tcp::TcpTransport;
-use crate::client::conn::transport::TransportStream;
-use crate::client::conn::Connection;
 use crate::client::conn::TlsTransport;
-use crate::client::pool::Checkout;
-use crate::client::pool::Connector;
-use crate::client::pool::{PoolableConnection, Pooled};
-use crate::client::Error as HyperdriverError;
-use crate::info::HasConnectionInfo;
+use crate::service::SharedService;
 
 mod builder;
-
 pub mod conn;
 pub mod pool;
+mod service;
 
 pub use builder::Builder;
 
@@ -98,155 +82,31 @@ pub fn default_tls_config() -> rustls::ClientConfig {
     cfg
 }
 
-/// An inner client HTTP service.
-#[derive(Debug)]
-pub struct ClientService<T, P, BOut>
-where
-    T: Transport,
-    P: Protocol<T::IO>,
-    P::Connection: PoolableConnection,
-{
-    transport: T,
-    protocol: P,
-    pool: Option<pool::Pool<P::Connection>>,
-    _body: std::marker::PhantomData<fn() -> BOut>,
-}
-
-impl<P, T, BOut> ClientService<T, P, BOut>
-where
-    T: Transport,
-    P: Protocol<T::IO>,
-    P::Connection: PoolableConnection,
-{
-    /// Create a new client with the given transport, protocol, and pool configuration.
-    pub fn new(transport: T, protocol: P, pool: pool::Config) -> Self {
-        Self {
-            transport,
-            protocol,
-            pool: Some(pool::Pool::new(pool)),
-            _body: std::marker::PhantomData,
-        }
-    }
-}
-
-impl ClientService<TlsTransport<TcpTransport>, HttpConnectionBuilder, crate::Body> {
-    /// Create a new client with the default configuration.
-    pub fn new_tcp_http() -> Self {
-        Self {
-            pool: Some(pool::Pool::new(pool::Config {
-                idle_timeout: Some(std::time::Duration::from_secs(90)),
-                max_idle_per_host: 32,
-            })),
-
-            transport: Default::default(),
-
-            protocol: HttpConnectionBuilder::default(),
-
-            _body: std::marker::PhantomData,
-        }
-    }
-}
-
-impl<P, T, B> Clone for ClientService<T, P, B>
-where
-    P: Protocol<T::IO> + Clone,
-    P::Connection: PoolableConnection,
-    T: Transport + Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            protocol: self.protocol.clone(),
-            transport: self.transport.clone(),
-            pool: self.pool.clone(),
-            _body: std::marker::PhantomData,
-        }
-    }
-}
-
-impl<P, C, T, B> ClientService<T, P, B>
-where
-    C: Connection + PoolableConnection,
-    P: Protocol<T::IO, Connection = C, Error = ConnectionError> + Clone + Send + Sync + 'static,
-    T: Transport + 'static,
-    T::IO: Unpin,
-    <<T as Transport>::IO as HasConnectionInfo>::Addr: Send,
-{
-    #[allow(clippy::type_complexity)]
-    fn connect_to(
-        &self,
-        uri: http::Uri,
-        http_protocol: HttpProtocol,
-    ) -> Result<Checkout<P::Connection, TransportStream<T::IO>, ConnectionError>, ConnectionError>
-    {
-        let key: pool::Key = uri.clone().try_into()?;
-        let mut protocol = self.protocol.clone();
-        let mut transport = self.transport.clone();
-
-        let connector = Connector::new(
-            move || async move {
-                poll_fn(|cx| Transport::poll_ready(&mut transport, cx))
-                    .await
-                    .map_err(|error| ConnectionError::Connecting(error.into()))?;
-                transport
-                    .connect(uri)
-                    .await
-                    .map_err(|error| ConnectionError::Connecting(error.into()))
-            },
-            Box::new(move |transport| {
-                Box::pin(async move {
-                    poll_fn(|cx| Protocol::poll_ready(&mut protocol, cx))
-                        .await
-                        .map_err(|error| ConnectionError::Handshake(error.into()))?;
-                    protocol
-                        .connect(transport, http_protocol)
-                        .await
-                        .map_err(|error| ConnectionError::Handshake(error.into()))
-                }) as _
-            }),
-        );
-
-        if let Some(pool) = self.pool.as_ref() {
-            Ok(pool.checkout(key, http_protocol.multiplex(), connector))
-        } else {
-            Ok(Checkout::detached(key, connector))
-        }
-    }
-}
-
-impl<P, C, T, BIn, BOut> tower::Service<http::Request<BIn>> for ClientService<T, P, BOut>
-where
-    C: Connection + PoolableConnection,
-    P: Protocol<T::IO, Connection = C, Error = ConnectionError> + Clone + Send + Sync + 'static,
-    T: Transport + 'static,
-    T::IO: Unpin,
-    BIn: Into<crate::body::Body>,
-    BOut: From<crate::body::Body> + Unpin,
-    <<T as Transport>::IO as HasConnectionInfo>::Addr: Send,
-    C::ResBody: Into<crate::Body>,
-{
-    type Response = http::Response<BOut>;
-    type Error = Error;
-    type Future = ResponseFuture<P::Connection, TransportStream<T::IO>, BOut>;
-
-    fn poll_ready(&mut self, _: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn call(&mut self, request: http::Request<BIn>) -> Self::Future {
-        let uri = request.uri().clone();
-
-        let protocol: HttpProtocol = request.version().into();
-
-        match self.connect_to(uri, protocol) {
-            Ok(checkout) => ResponseFuture::new(checkout, request.map(Into::into)),
-            Err(error) => ResponseFuture::error(error),
-        }
-    }
-}
-
 /// Client service for TCP connections with TLS and HTTP.
 pub type ClientTlsTcpService =
     ClientService<TlsTransport<TcpTransport>, HttpConnectionBuilder, crate::Body>;
+
+/// A boxed service with http::Request and http::Response and symmetric body types
+pub type BoxedClientService<B> = SharedService<http::Request<B>, http::Response<B>, Error>;
+
+struct ClientRef {
+    service: BoxedClientService<crate::Body>,
+}
+
+impl ClientRef {
+    fn new(service: impl Into<BoxedClientService<crate::Body>>) -> Self {
+        Self {
+            service: service.into(),
+        }
+    }
+
+    fn request(
+        &self,
+        request: crate::body::Request,
+    ) -> Oneshot<BoxedClientService<crate::Body>, http::Request<crate::Body>> {
+        self.service.clone().oneshot(request)
+    }
+}
 
 /// A simple async HTTP client.
 ///
@@ -258,88 +118,65 @@ pub type ClientTlsTcpService =
 /// ```no_run
 /// # use hyperdriver::client::Client;
 /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-/// let mut client = Client::new_tcp_http();
+/// let client = Client::build_tcp_http().build();
 /// let response = client.get("http://example.com".parse().unwrap()).await.unwrap();
 /// println!("Response: {:?}", response);
 /// # Ok(())
 /// # }
 /// ```
 #[derive(Clone)]
-pub struct Client<S = ClientTlsTcpService> {
-    service: S,
+pub struct Client {
+    inner: Arc<ClientRef>,
 }
 
-impl<S> fmt::Debug for Client<S> {
+impl fmt::Debug for Client {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Client").finish()
     }
 }
 
-impl<T, P, B> Client<ClientService<T, P, B>>
-where
-    T: Transport,
-    P: Protocol<T::IO>,
-    P::Connection: PoolableConnection,
-{
-    /// Create a new client with the given connector and pool configuration.
-    pub fn new(protocol: P, transport: T, pool: pool::Config) -> Self {
-        Self {
-            service: ClientService::new(transport, protocol, pool),
-        }
-    }
-}
-
-impl Client<()> {
-    /// Create a new client builder
-    pub fn builder() -> self::Builder {
-        self::Builder::default()
-    }
-}
-
-#[cfg(feature = "stream")]
-impl Default for Client<ClientTlsTcpService> {
+impl Default for Client {
     fn default() -> Self {
-        Self {
-            service: ClientService::new_tcp_http(),
-        }
+        Builder::default().build()
     }
 }
 
-#[cfg(feature = "stream")]
-impl Client<ClientTlsTcpService> {
-    /// Create a new client that uses TCP and HTTP.
-    pub fn new_tcp_http() -> Self {
-        Self::default()
-    }
-}
-
-impl<S> Client<S> {
-    /// Apply a layer to the client
-    pub fn layer<L>(self, layer: L) -> Client<L::Service>
+impl Client {
+    /// Create a new client from a raw service.
+    ///
+    /// It is much easier to use the builder interface to create a client.
+    pub fn new_from_service<S>(service: S) -> Self
     where
-        L: tower::Layer<S>,
+        S: Into<BoxedClientService<crate::Body>>,
     {
         Client {
-            service: layer.layer(self.service),
+            inner: Arc::new(ClientRef::new(service)),
         }
+    }
+
+    /// Create a new, empty builder for clients.
+    pub fn builder() -> self::builder::Builder<(), ()> {
+        Builder::new()
+    }
+
+    /// Create a new client builder with default settings applied.
+    pub fn build_tcp_http(
+    ) -> self::builder::Builder<TcpTransportConfig, auto::HttpConnectionBuilder> {
+        Builder::default()
     }
 }
 
-impl<S> Client<S>
-where
-    S: tower::Service<http::Request<crate::Body>, Response = http::Response<crate::Body>> + Clone,
-    Error: From<S::Error>,
-{
+impl Client {
     /// Send an http Request, and return a Future of the Response.
     pub fn request(
-        &mut self,
+        &self,
         request: crate::body::Request,
-    ) -> Oneshot<S, http::Request<crate::Body>> {
-        self.service.clone().oneshot(request)
+    ) -> Oneshot<BoxedClientService<crate::Body>, http::Request<crate::Body>> {
+        self.inner.request(request)
     }
 
     /// Make a GET request to the given URI.
-    pub async fn get(&mut self, uri: http::Uri) -> Result<http::Response<crate::Body>, Error> {
+    pub async fn get(&self, uri: http::Uri) -> Result<http::Response<crate::Body>, Error> {
         let request = http::Request::get(uri.clone())
             .body(crate::body::Body::empty())
             .unwrap();
@@ -349,437 +186,12 @@ where
     }
 }
 
-/// A future that resolves to an HTTP response.
-pub struct ResponseFuture<C, T, BOut = crate::Body>
-where
-    C: pool::PoolableConnection,
-    T: pool::PoolableTransport,
-{
-    inner: ResponseFutureState<C, T>,
-    _body: std::marker::PhantomData<fn() -> BOut>,
-}
-
-impl<C: pool::PoolableConnection, T: pool::PoolableTransport, B> fmt::Debug
-    for ResponseFuture<C, T, B>
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ResponseFuture").finish()
-    }
-}
-
-impl<C, T, BOut> ResponseFuture<C, T, BOut>
-where
-    C: pool::PoolableConnection,
-    T: pool::PoolableTransport,
-{
-    fn new(checkout: Checkout<C, T, ConnectionError>, request: crate::body::Request) -> Self {
-        Self {
-            inner: ResponseFutureState::Checkout { checkout, request },
-            _body: std::marker::PhantomData,
-        }
-    }
-
-    fn error(error: ConnectionError) -> Self {
-        Self {
-            inner: ResponseFutureState::ConnectionError(error),
-            _body: std::marker::PhantomData,
-        }
-    }
-}
-
-impl<C, T, BOut> Future for ResponseFuture<C, T, BOut>
-where
-    C: Connection + pool::PoolableConnection,
-    C::ResBody: Into<crate::body::Body>,
-    T: pool::PoolableTransport,
-    BOut: From<crate::body::Body> + Unpin,
-{
-    type Output = Result<http::Response<BOut>, Error>;
-
-    fn poll(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> Poll<Self::Output> {
-        loop {
-            match std::mem::replace(&mut self.inner, ResponseFutureState::Empty) {
-                ResponseFutureState::Checkout {
-                    mut checkout,
-                    request,
-                } => match checkout.poll_unpin(cx) {
-                    Poll::Ready(Ok(conn)) => {
-                        self.inner =
-                            ResponseFutureState::Request(execute_request(request, conn).boxed());
-                    }
-                    Poll::Ready(Err(error)) => {
-                        return Poll::Ready(Err(error.into()));
-                    }
-                    Poll::Pending => {
-                        self.inner = ResponseFutureState::Checkout { checkout, request };
-                        return Poll::Pending;
-                    }
-                },
-                ResponseFutureState::Request(mut fut) => match fut.poll_unpin(cx) {
-                    Poll::Ready(Ok(response)) => return Poll::Ready(Ok(response.map(Into::into))),
-                    Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
-                    Poll::Pending => {
-                        self.inner = ResponseFutureState::Request(fut);
-                        return Poll::Pending;
-                    }
-                },
-                ResponseFutureState::ConnectionError(error) => {
-                    return Poll::Ready(Err(Error::Connection(error.into())));
-                }
-                ResponseFutureState::Empty => {
-                    panic!("future polled after completion");
-                }
-            }
-        }
-    }
-}
-
-enum ResponseFutureState<C: pool::PoolableConnection, T: pool::PoolableTransport> {
-    Empty,
-    Checkout {
-        checkout: Checkout<C, T, ConnectionError>,
-        request: crate::body::Request,
-    },
-    ConnectionError(ConnectionError),
-    Request(BoxFuture<'static, Result<http::Response<crate::body::Body>, HyperdriverError>>),
-}
-
-/// Prepare a request for sending over the connection.
-fn prepare_request<C: Connection + PoolableConnection>(
-    request: &mut http::Request<crate::body::Body>,
-    conn: &Pooled<C>,
-) -> Result<(), Error> {
-    request
-        .headers_mut()
-        .entry(http::header::USER_AGENT)
-        .or_insert_with(|| {
-            HeaderValue::from_static(concat!(
-                env!("CARGO_PKG_NAME"),
-                "/",
-                env!("CARGO_PKG_VERSION")
-            ))
-        });
-
-    if conn.version() == Version::HTTP_11 {
-        if request.version() == Version::HTTP_2 {
-            warn!("refusing to send HTTP/2 request to HTTP/1.1 connection");
-            return Err(Error::UnsupportedProtocol);
-        }
-
-        //TODO: Configure set host header?
-        set_host_header(request);
-
-        if request.method() == http::Method::CONNECT {
-            authority_form(request.uri_mut());
-
-            // If the URI is to HTTPS, and the connector claimed to be a proxy,
-            // then it *should* have tunneled, and so we don't want to send
-            // absolute-form in that case.
-            if request.uri().scheme() == Some(&Scheme::HTTPS) {
-                origin_form(request.uri_mut());
-            }
-        } else if request.uri().scheme().is_none() || request.uri().authority().is_none() {
-            absolute_form(request.uri_mut());
-        } else {
-            origin_form(request.uri_mut());
-        }
-    } else if request.method() == http::Method::CONNECT {
-        return Err(Error::InvalidMethod(http::Method::CONNECT));
-    } else if conn.version() == Version::HTTP_2 {
-        set_host_header(request);
-    }
-    Ok(())
-}
-
-async fn execute_request<C>(
-    mut request: crate::body::Request,
-    mut conn: Pooled<C>,
-) -> Result<http::Response<crate::body::Body>, Error>
-where
-    C: Connection + PoolableConnection,
-    C::ResBody: Into<crate::Body>,
-{
-    prepare_request(&mut request, &conn)?;
-
-    tracing::trace!(request.uri=%request.uri(), conn.version=?conn.version(), req.version=?request.version(), "sending request");
-
-    let response = conn
-        .send_request(request)
-        .await
-        .map_err(|error| Error::Connection(error.into()))?;
-
-    // Shared connections are already in the pool, no need to do this.
-    if !conn.can_share() {
-        // Only re-insert the connection when it is ready again. Spawn
-        // a task to wait for the connection to become ready before dropping.
-        tokio::spawn(async move {
-            let _ = conn.when_ready().await.map_err(|_| ());
-        });
-    }
-
-    Ok(response.map(|body| body.into()))
-}
-
-/// Convert the URI to authority-form, if it is not already.
-///
-/// This is the form of the URI with just the authority and a default
-/// path and scheme. This is used in HTTP/1 CONNECT requests.
-fn authority_form(uri: &mut Uri) {
-    *uri = match uri.authority() {
-        Some(auth) => {
-            let mut parts = ::http::uri::Parts::default();
-            parts.authority = Some(auth.clone());
-            Uri::from_parts(parts).expect("authority is valid")
-        }
-        None => {
-            unreachable!("authority_form with relative uri");
-        }
-    };
-}
-
-fn absolute_form(uri: &mut Uri) {
-    debug_assert!(uri.scheme().is_some(), "absolute_form needs a scheme");
-    debug_assert!(
-        uri.authority().is_some(),
-        "absolute_form needs an authority"
-    );
-}
-
-/// Convert the URI to origin-form, if it is not already.
-///
-/// This form of the URI has no scheme or authority, and contains just
-/// the path, usually used in HTTP/1 requests.
-fn origin_form(uri: &mut Uri) {
-    let path = match uri.path_and_query() {
-        Some(path) if path.as_str() != "/" => {
-            let mut parts = ::http::uri::Parts::default();
-            parts.path_and_query = Some(path.clone());
-            Uri::from_parts(parts).expect("path is valid uri")
-        }
-        _none_or_just_slash => {
-            debug_assert!(Uri::default() == "/");
-            Uri::default()
-        }
-    };
-    *uri = path
-}
-
-/// Returns the port if it is not the default port for the scheme.
-fn get_non_default_port(uri: &Uri) -> Option<Port<&str>> {
-    match (uri.port().map(|p| p.as_u16()), is_schema_secure(uri)) {
-        (Some(443), true) => None,
-        (Some(80), false) => None,
-        _ => uri.port(),
-    }
-}
-
-/// Returns true if the URI scheme is presumed secure.
-fn is_schema_secure(uri: &Uri) -> bool {
-    uri.scheme_str()
-        .map(|scheme_str| matches!(scheme_str, "wss" | "https"))
-        .unwrap_or_default()
-}
-
-/// Set the Host header on the request if it is not already set,
-/// using the authority from the URI.
-fn set_host_header<B>(request: &mut http::Request<B>) {
-    let uri = request.uri().clone();
-    request
-        .headers_mut()
-        .entry(http::header::HOST)
-        .or_insert_with(|| {
-            let hostname = uri.host().expect("authority implies host");
-            if let Some(port) = get_non_default_port(&uri) {
-                let s = format!("{}:{}", hostname, port);
-                HeaderValue::from_str(&s)
-            } else {
-                HeaderValue::from_str(hostname)
-            }
-            .expect("uri host is valid header value")
-        });
-}
-
 #[cfg(test)]
 mod tests {
 
-    #[cfg(feature = "mocks")]
-    use crate::Body;
+    use static_assertions::assert_impl_all;
 
-    #[cfg(feature = "mocks")]
-    use self::conn::protocol::mock::MockProtocol;
-    #[cfg(feature = "mocks")]
-    use self::conn::transport::mock::{MockConnectionError, MockTransport};
+    use crate::Client;
 
-    use super::*;
-
-    #[test]
-    fn test_set_host_header() {
-        let mut request = http::Request::new(());
-        *request.uri_mut() = "http://example.com".parse().unwrap();
-        set_host_header(&mut request);
-        assert_eq!(
-            request.headers().get(http::header::HOST).unwrap(),
-            "example.com"
-        );
-
-        let mut request = http::Request::new(());
-        *request.uri_mut() = "http://example.com:8080".parse().unwrap();
-        set_host_header(&mut request);
-        assert_eq!(
-            request.headers().get(http::header::HOST).unwrap(),
-            "example.com:8080"
-        );
-
-        let mut request = http::Request::new(());
-        *request.uri_mut() = "https://example.com".parse().unwrap();
-        set_host_header(&mut request);
-        assert_eq!(
-            request.headers().get(http::header::HOST).unwrap(),
-            "example.com"
-        );
-
-        let mut request = http::Request::new(());
-        *request.uri_mut() = "https://example.com:8443".parse().unwrap();
-        set_host_header(&mut request);
-        assert_eq!(
-            request.headers().get(http::header::HOST).unwrap(),
-            "example.com:8443"
-        );
-    }
-
-    #[test]
-    fn test_is_schema_secure() {
-        let uri = "http://example.com".parse().unwrap();
-        assert!(!is_schema_secure(&uri));
-
-        let uri = "https://example.com".parse().unwrap();
-        assert!(is_schema_secure(&uri));
-
-        let uri = "ws://example.com".parse().unwrap();
-        assert!(!is_schema_secure(&uri));
-
-        let uri = "wss://example.com".parse().unwrap();
-        assert!(is_schema_secure(&uri));
-    }
-
-    #[test]
-    fn test_get_non_default_port() {
-        let uri = "http://example.com".parse().unwrap();
-        assert_eq!(get_non_default_port(&uri).map(|p| p.as_u16()), None);
-
-        let uri = "http://example.com:8080".parse().unwrap();
-        assert_eq!(get_non_default_port(&uri).map(|p| p.as_u16()), Some(8080));
-
-        let uri = "https://example.com".parse().unwrap();
-        assert_eq!(get_non_default_port(&uri).map(|p| p.as_u16()), None);
-
-        let uri = "https://example.com:8443".parse().unwrap();
-        assert_eq!(get_non_default_port(&uri).map(|p| p.as_u16()), Some(8443));
-    }
-
-    #[test]
-    fn test_origin_form() {
-        let mut uri = "http://example.com".parse().unwrap();
-        origin_form(&mut uri);
-        assert_eq!(uri, "/");
-
-        let mut uri = "/some/path/here".parse().unwrap();
-        origin_form(&mut uri);
-        assert_eq!(uri, "/some/path/here");
-
-        let mut uri = "http://example.com:8080/some/path?query#fragment"
-            .parse()
-            .unwrap();
-        origin_form(&mut uri);
-        assert_eq!(uri, "/some/path?query");
-
-        let mut uri = "/".parse().unwrap();
-        origin_form(&mut uri);
-        assert_eq!(uri, "/");
-    }
-
-    #[test]
-    fn test_absolute_form() {
-        let mut uri = "http://example.com".parse().unwrap();
-        absolute_form(&mut uri);
-        assert_eq!(uri, "http://example.com");
-
-        let mut uri = "http://example.com:8080".parse().unwrap();
-        absolute_form(&mut uri);
-        assert_eq!(uri, "http://example.com:8080");
-
-        let mut uri = "https://example.com/some/path?query".parse().unwrap();
-        absolute_form(&mut uri);
-        assert_eq!(uri, "https://example.com/some/path?query");
-
-        let mut uri = "https://example.com:8443".parse().unwrap();
-        absolute_form(&mut uri);
-        assert_eq!(uri, "https://example.com:8443");
-
-        let mut uri = "http://example.com:443".parse().unwrap();
-        absolute_form(&mut uri);
-        assert_eq!(uri, "http://example.com:443");
-
-        let mut uri = "https://example.com:80".parse().unwrap();
-        absolute_form(&mut uri);
-        assert_eq!(uri, "https://example.com:80");
-    }
-
-    #[cfg(feature = "mocks")]
-    #[tokio::test]
-    async fn test_client_mock_transport() {
-        let transport = MockTransport::new(false);
-        let protocol = MockProtocol;
-        let pool = PoolConfig::default();
-
-        let mut client: Client<ClientService<MockTransport, MockProtocol, Body>> =
-            Client::new(protocol, transport, pool);
-
-        client
-            .request(
-                http::Request::builder()
-                    .uri("mock://somewhere")
-                    .body(crate::Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-    }
-
-    #[cfg(feature = "mocks")]
-    #[tokio::test]
-    async fn test_client_mock_connection_error() {
-        let transport = MockTransport::connection_error();
-        let protocol = MockProtocol;
-        let pool = PoolConfig::default();
-
-        let mut client: Client<ClientService<MockTransport, MockProtocol, Body>> =
-            Client::new(protocol, transport, pool);
-
-        let result = client
-            .request(
-                http::Request::builder()
-                    .uri("mock://somewhere")
-                    .body(crate::Body::empty())
-                    .unwrap(),
-            )
-            .await;
-
-        let err = result.unwrap_err();
-
-        let Error::Connection(err) = err else {
-            panic!("unexpected error: {:?}", err);
-        };
-
-        let err = err.downcast::<ConnectionError>().unwrap();
-
-        let ConnectionError::Connecting(err) = *err else {
-            panic!("unexpected error: {:?}", err);
-        };
-
-        err.downcast::<MockConnectionError>().unwrap();
-    }
+    assert_impl_all!(Client: Send, Sync);
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,4 +1,16 @@
 //! HTTP client library for Rust, built on top of [hyper].
+//!
+//! There are three levels of available APIs in this library:
+//!
+//! 1. The high-level [`Client`] API, which is the most user-friendly and abstracts away most of the details.
+//!    It is "batteries-included", and supports features like redirects, retries and timeouts.
+//! 2. The [`Service`][ClientService] API, which is a lower-level API that allows for more control over the request and response.
+//!    It presents a `tower::Service` that can be used to send requests and receive responses, and can be wrapped
+//!    by middleware compatible with the tower ecosystem.
+//! 3. The [connection][self::conn] API, which is the lowest-level API that allows for direct control over the
+//!    transport and protocol layers. This API is useful for implementing custom transports or protocols, but
+//!    might be difficult to directly use as a client.
+//!
 
 use std::fmt;
 use std::sync::Arc;
@@ -86,6 +98,7 @@ pub type BoxedClientService<B> = SharedService<
     Box<dyn std::error::Error + Send + Sync + 'static>,
 >;
 
+/// Inner type for managing the client service.
 struct ClientRef {
     service: BoxedClientService<crate::Body>,
 }
@@ -105,11 +118,10 @@ impl ClientRef {
     }
 }
 
-/// A simple, high-level, async HTTP client.
+/// A high-level async HTTP client.
 ///
-/// This client is built on top of the `tokio` runtime and the `hyper` HTTP library.
-/// It combines a connection pool with a transport layer to provide a simple API for
-/// sending HTTP requests.
+/// This client is built on top of the [`Service`][ClientService] API and provides a more user-friendly interface,
+/// including support for retries, redirects and timeouts.
 ///
 /// # Example
 /// ```no_run
@@ -160,6 +172,12 @@ impl Client {
     pub fn build_tcp_http(
     ) -> self::builder::Builder<TcpTransportConfig, auto::HttpConnectionBuilder> {
         Builder::default()
+    }
+
+    /// Create a new client with default settings applied for TCP connections
+    /// (with TLS support) and HTTP/1.1 or HTTP/2.
+    pub fn new_tcp_http() -> Self {
+        Builder::default().build()
     }
 }
 

--- a/src/client/pool/mod.rs
+++ b/src/client/pool/mod.rs
@@ -240,7 +240,7 @@ pub trait PoolableTransport: Unpin + Send + Sized + 'static {
     fn can_share(&self) -> bool;
 }
 
-/// A [`crate::client::Protocol`] that can be pooled.
+/// A [`crate::client::conn::Protocol`] that can be pooled.
 pub trait PoolableConnection: Unpin + Send + Sized + 'static {
     /// Returns `true` if the connection is open.
     fn is_open(&self) -> bool;

--- a/src/client/pool/mod.rs
+++ b/src/client/pool/mod.rs
@@ -1,4 +1,18 @@
 //! Connection Pooling for Clients
+//!
+//! The `pool` module provides a connection pool for clients, which allows for multiple connections to be made to a
+//! remote host and reused across multiple requests. This is supported in the `ClientService` type.
+//!
+//! This connection pool is specifically designed with HTTP connections in mind. It separates the treatment of the
+//! connection (e.g. HTTP/1.1, HTTP/2, etc) from the transport (e.g. TCP, TCP+TLS, etc). This allows the pool to be used
+//! with any type of connection, as long as it implements the `PoolableConnection` trait, and any type of transport,
+//! as long as it implements the `PoolableTransport` trait. This also allows the pool to be used with upgradeable
+//! connections, such as HTTP/1.1 connections that can be upgraded to HTTP/2, where the pool will have new HTTP/2
+//! connections wait for in-progress upgrades from HTTP/1.1 connections to complete and use those, rather than creating
+//! new connections.
+//!
+//! Pool configuration happens in the `Config` type, which allows for setting the maximum idle duration of a connection,
+//! and the maximum number of idle connections per host.
 
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -27,14 +41,6 @@ use self::weakopt::WeakOpt;
 
 /// A pool of connections to remote hosts.
 ///
-/// This connection pool is specifically designed with HTTP connections in mind. It separates the treatment of the
-/// connection (e.g. HTTP/1.1, HTTP/2, etc) from the transport (e.g. TCP, TLS, etc). This allows the pool to be used
-/// with any type of connection, as long as it implements the `PoolableConnection` trait, and any type of transport,
-/// as long as it implements the `PoolableTransport` trait. This also allows the pool to be used with upgradeable
-/// connections, such as HTTP/1.1 connections that can be upgraded to HTTP/2, where the pool will have new HTTP/2
-/// connections wait for in-progress upgrades from HTTP/1.1 connections to complete and use those, rather than creating
-/// new connections.
-///
 /// The pool makes use of a `Checkout` to represent a connection that is being checked out of the pool. The `Checkout`
 /// type requires a `Connector` to be provided, which provides a future that will create a new connection to the remote
 /// host, and a future that will perform the handshake for the connection. The `Checkout` ensures that in-progress
@@ -43,9 +49,6 @@ use self::weakopt::WeakOpt;
 /// The pool also provides a `Pooled` type, which is a wrapper around a connection that will return the connection to
 /// the pool when dropped, if the connection is still open and has not been marked as reusable (reusable connections
 /// are always kept in the pool - there is no need to return dropped copies).
-///
-/// Pool configuration happens in the `Config` type, which allows for setting the maximum idle duration of a connection,
-/// and the maximum number of idle connections per host.
 #[derive(Debug)]
 pub(crate) struct Pool<T: PoolableConnection> {
     inner: Arc<Mutex<PoolInner<T>>>,
@@ -228,7 +231,14 @@ impl Default for Config {
     }
 }
 
-/// A [`crate::client::conn::Transport`] that can be pooled.
+/// A [`crate::client::conn::Transport`] that can produce connections
+/// which might be poolable.
+///
+/// This trait is used by the pool connection checkout process before
+/// the handshake occurs to check if the connection has negotiated or
+/// upgraded to a protocol which enables multiplexing. This is an
+/// optimistic check, and the connection will be checked again after
+/// the handshake is complete.
 pub trait PoolableTransport: Unpin + Send + Sized + 'static {
     /// Returns `true` if the transport can be re-used, usually
     /// because it has used ALPN to negotiate a protocol that can
@@ -240,7 +250,14 @@ pub trait PoolableTransport: Unpin + Send + Sized + 'static {
     fn can_share(&self) -> bool;
 }
 
-/// A [`crate::client::conn::Protocol`] that can be pooled.
+/// A [`crate::client::conn::Connection`] that can be pooled.
+///
+/// These connections must report to the pool whether they remain open,
+/// and whether they can be shared / multiplexed.
+///
+/// The pool will call [`PoolableConnection::reuse`] to get a new connection
+/// to return to the pool, which will multiplex against this one. If multiplexing
+/// is not possible, then `None` should be returned.
 pub trait PoolableConnection: Unpin + Send + Sized + 'static {
     /// Returns `true` if the connection is open.
     fn is_open(&self) -> bool;

--- a/src/client/service.rs
+++ b/src/client/service.rs
@@ -1,0 +1,636 @@
+use std::fmt;
+use std::future::poll_fn;
+use std::future::Future;
+use std::task::Poll;
+
+use futures_util::future::BoxFuture;
+use futures_util::FutureExt;
+use http::uri::Port;
+use http::uri::Scheme;
+use http::HeaderValue;
+use http::Uri;
+use http::Version;
+use tower::util::Oneshot;
+use tower::ServiceExt;
+use tracing::warn;
+
+use super::conn::connection::ConnectionError;
+use super::conn::protocol::auto::HttpConnectionBuilder;
+use super::conn::protocol::HttpProtocol;
+use super::conn::transport::tcp::TcpTransport;
+use super::conn::transport::TransportStream;
+use super::conn::Connection;
+use super::conn::Protocol;
+use super::conn::TlsTransport;
+use super::conn::Transport;
+use super::pool;
+use super::pool::Checkout;
+use super::pool::Connector;
+use super::pool::PoolableConnection;
+use super::pool::Pooled;
+use super::Error;
+use crate::info::HasConnectionInfo;
+
+/// A client built from the minium constituents to provide
+/// a simple HTTP `tower::Service`. This is the low-level
+/// entry-point to building a client.
+#[derive(Debug)]
+pub struct ClientService<T, P, BOut = crate::Body>
+where
+    T: Transport,
+    P: Protocol<T::IO>,
+    P::Connection: PoolableConnection,
+{
+    pub(super) transport: T,
+    pub(super) protocol: P,
+    pub(super) pool: Option<pool::Pool<P::Connection>>,
+    pub(super) _body: std::marker::PhantomData<fn() -> BOut>,
+}
+
+impl<P, T, BOut> ClientService<T, P, BOut>
+where
+    T: Transport,
+    P: Protocol<T::IO>,
+    P::Connection: PoolableConnection,
+{
+    /// Create a new client with the given transport, protocol, and pool configuration.
+    pub fn new(transport: T, protocol: P, pool: pool::Config) -> Self {
+        Self {
+            transport,
+            protocol,
+            pool: Some(pool::Pool::new(pool)),
+            _body: std::marker::PhantomData,
+        }
+    }
+}
+
+impl ClientService<TlsTransport<TcpTransport>, HttpConnectionBuilder, crate::Body> {
+    /// Create a new client with the default configuration.
+    pub fn new_tcp_http() -> Self {
+        Self {
+            pool: Some(pool::Pool::new(pool::Config {
+                idle_timeout: Some(std::time::Duration::from_secs(90)),
+                max_idle_per_host: 32,
+            })),
+
+            transport: Default::default(),
+
+            protocol: HttpConnectionBuilder::default(),
+
+            _body: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<P, T, B> Clone for ClientService<T, P, B>
+where
+    P: Protocol<T::IO> + Clone,
+    P::Connection: PoolableConnection,
+    T: Transport + Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            protocol: self.protocol.clone(),
+            transport: self.transport.clone(),
+            pool: self.pool.clone(),
+            _body: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<P, C, T, B> ClientService<T, P, B>
+where
+    C: Connection + PoolableConnection,
+    P: Protocol<T::IO, Connection = C, Error = ConnectionError> + Clone + Send + Sync + 'static,
+    T: Transport + 'static,
+    T::IO: Unpin,
+    <<T as Transport>::IO as HasConnectionInfo>::Addr: Send,
+{
+    #[allow(clippy::type_complexity)]
+    fn connect_to(
+        &self,
+        uri: http::Uri,
+        http_protocol: HttpProtocol,
+    ) -> Result<Checkout<P::Connection, TransportStream<T::IO>, ConnectionError>, ConnectionError>
+    {
+        let key: pool::Key = uri.clone().try_into()?;
+        let mut protocol = self.protocol.clone();
+        let mut transport = self.transport.clone();
+
+        let connector = Connector::new(
+            move || async move {
+                poll_fn(|cx| Transport::poll_ready(&mut transport, cx))
+                    .await
+                    .map_err(|error| ConnectionError::Connecting(error.into()))?;
+                transport
+                    .connect(uri)
+                    .await
+                    .map_err(|error| ConnectionError::Connecting(error.into()))
+            },
+            Box::new(move |transport| {
+                Box::pin(async move {
+                    poll_fn(|cx| Protocol::poll_ready(&mut protocol, cx))
+                        .await
+                        .map_err(|error| ConnectionError::Handshake(error.into()))?;
+                    protocol
+                        .connect(transport, http_protocol)
+                        .await
+                        .map_err(|error| ConnectionError::Handshake(error.into()))
+                }) as _
+            }),
+        );
+
+        if let Some(pool) = self.pool.as_ref() {
+            Ok(pool.checkout(key, http_protocol.multiplex(), connector))
+        } else {
+            Ok(Checkout::detached(key, connector))
+        }
+    }
+}
+
+impl<P, C, T, BIn, BOut> tower::Service<http::Request<BIn>> for ClientService<T, P, BOut>
+where
+    C: Connection + PoolableConnection,
+    P: Protocol<T::IO, Connection = C, Error = ConnectionError> + Clone + Send + Sync + 'static,
+    T: Transport + 'static,
+    T::IO: Unpin,
+    BIn: Into<crate::body::Body>,
+    BOut: From<crate::body::Body> + Unpin,
+    <<T as Transport>::IO as HasConnectionInfo>::Addr: Send,
+    C::ResBody: Into<crate::Body>,
+{
+    type Response = http::Response<BOut>;
+    type Error = Error;
+    type Future = ResponseFuture<P::Connection, TransportStream<T::IO>, BOut>;
+
+    fn poll_ready(&mut self, _: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: http::Request<BIn>) -> Self::Future {
+        let uri = request.uri().clone();
+
+        let protocol: HttpProtocol = request.version().into();
+
+        match self.connect_to(uri, protocol) {
+            Ok(checkout) => ResponseFuture::new(checkout, request.map(Into::into)),
+            Err(error) => ResponseFuture::error(error),
+        }
+    }
+}
+
+impl<P, C, T, BOut> ClientService<T, P, BOut>
+where
+    C: Connection + PoolableConnection,
+    P: Protocol<T::IO, Connection = C, Error = ConnectionError> + Clone + Send + Sync + 'static,
+    T: Transport + 'static,
+    T::IO: Unpin,
+    BOut: From<crate::body::Body> + Unpin,
+    <<T as Transport>::IO as HasConnectionInfo>::Addr: Send,
+    C::ResBody: Into<crate::Body>,
+{
+    /// Send an http Request, and return a Future of the Response.
+    pub fn request(
+        &self,
+        request: crate::body::Request,
+    ) -> Oneshot<Self, http::Request<crate::Body>> {
+        self.clone().oneshot(request)
+    }
+}
+
+/// A future that resolves to an HTTP response.
+pub struct ResponseFuture<C, T, BOut = crate::Body>
+where
+    C: pool::PoolableConnection,
+    T: pool::PoolableTransport,
+{
+    inner: ResponseFutureState<C, T>,
+    _body: std::marker::PhantomData<fn() -> BOut>,
+}
+
+impl<C: pool::PoolableConnection, T: pool::PoolableTransport, B> fmt::Debug
+    for ResponseFuture<C, T, B>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ResponseFuture").finish()
+    }
+}
+
+impl<C, T, BOut> ResponseFuture<C, T, BOut>
+where
+    C: pool::PoolableConnection,
+    T: pool::PoolableTransport,
+{
+    fn new(checkout: Checkout<C, T, ConnectionError>, request: crate::body::Request) -> Self {
+        Self {
+            inner: ResponseFutureState::Checkout { checkout, request },
+            _body: std::marker::PhantomData,
+        }
+    }
+
+    fn error(error: ConnectionError) -> Self {
+        Self {
+            inner: ResponseFutureState::ConnectionError(error),
+            _body: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<C, T, BOut> Future for ResponseFuture<C, T, BOut>
+where
+    C: Connection + pool::PoolableConnection,
+    C::ResBody: Into<crate::body::Body>,
+    T: pool::PoolableTransport,
+    BOut: From<crate::body::Body> + Unpin,
+{
+    type Output = Result<http::Response<BOut>, Error>;
+
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Self::Output> {
+        loop {
+            match std::mem::replace(&mut self.inner, ResponseFutureState::Empty) {
+                ResponseFutureState::Checkout {
+                    mut checkout,
+                    request,
+                } => match checkout.poll_unpin(cx) {
+                    Poll::Ready(Ok(conn)) => {
+                        self.inner =
+                            ResponseFutureState::Request(execute_request(request, conn).boxed());
+                    }
+                    Poll::Ready(Err(error)) => {
+                        return Poll::Ready(Err(error.into()));
+                    }
+                    Poll::Pending => {
+                        self.inner = ResponseFutureState::Checkout { checkout, request };
+                        return Poll::Pending;
+                    }
+                },
+                ResponseFutureState::Request(mut fut) => match fut.poll_unpin(cx) {
+                    Poll::Ready(Ok(response)) => return Poll::Ready(Ok(response.map(Into::into))),
+                    Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
+                    Poll::Pending => {
+                        self.inner = ResponseFutureState::Request(fut);
+                        return Poll::Pending;
+                    }
+                },
+                ResponseFutureState::ConnectionError(error) => {
+                    return Poll::Ready(Err(Error::Connection(error.into())));
+                }
+                ResponseFutureState::Empty => {
+                    panic!("future polled after completion");
+                }
+            }
+        }
+    }
+}
+
+enum ResponseFutureState<C: pool::PoolableConnection, T: pool::PoolableTransport> {
+    Empty,
+    Checkout {
+        checkout: Checkout<C, T, ConnectionError>,
+        request: crate::body::Request,
+    },
+    ConnectionError(ConnectionError),
+    Request(BoxFuture<'static, Result<http::Response<crate::body::Body>, Error>>),
+}
+
+/// Prepare a request for sending over the connection.
+fn prepare_request<C: Connection + PoolableConnection>(
+    request: &mut http::Request<crate::body::Body>,
+    conn: &Pooled<C>,
+) -> Result<(), Error> {
+    request
+        .headers_mut()
+        .entry(http::header::USER_AGENT)
+        .or_insert_with(|| {
+            HeaderValue::from_static(concat!(
+                env!("CARGO_PKG_NAME"),
+                "/",
+                env!("CARGO_PKG_VERSION")
+            ))
+        });
+
+    if conn.version() == Version::HTTP_11 {
+        if request.version() == Version::HTTP_2 {
+            warn!("refusing to send HTTP/2 request to HTTP/1.1 connection");
+            return Err(Error::UnsupportedProtocol);
+        }
+
+        //TODO: Configure set host header?
+        set_host_header(request);
+
+        if request.method() == http::Method::CONNECT {
+            authority_form(request.uri_mut());
+
+            // If the URI is to HTTPS, and the connector claimed to be a proxy,
+            // then it *should* have tunneled, and so we don't want to send
+            // absolute-form in that case.
+            if request.uri().scheme() == Some(&Scheme::HTTPS) {
+                origin_form(request.uri_mut());
+            }
+        } else if request.uri().scheme().is_none() || request.uri().authority().is_none() {
+            absolute_form(request.uri_mut());
+        } else {
+            origin_form(request.uri_mut());
+        }
+    } else if request.method() == http::Method::CONNECT {
+        return Err(Error::InvalidMethod(http::Method::CONNECT));
+    } else if conn.version() == Version::HTTP_2 {
+        set_host_header(request);
+    }
+    Ok(())
+}
+
+async fn execute_request<C>(
+    mut request: crate::body::Request,
+    mut conn: Pooled<C>,
+) -> Result<http::Response<crate::body::Body>, Error>
+where
+    C: Connection + PoolableConnection,
+    C::ResBody: Into<crate::Body>,
+{
+    prepare_request(&mut request, &conn)?;
+
+    tracing::trace!(request.uri=%request.uri(), conn.version=?conn.version(), req.version=?request.version(), "sending request");
+
+    let response = conn
+        .send_request(request)
+        .await
+        .map_err(|error| Error::Connection(error.into()))?;
+
+    // Shared connections are already in the pool, no need to do this.
+    if !conn.can_share() {
+        // Only re-insert the connection when it is ready again. Spawn
+        // a task to wait for the connection to become ready before dropping.
+        tokio::spawn(async move {
+            let _ = conn.when_ready().await.map_err(|_| ());
+        });
+    }
+
+    Ok(response.map(|body| body.into()))
+}
+
+/// Convert the URI to authority-form, if it is not already.
+///
+/// This is the form of the URI with just the authority and a default
+/// path and scheme. This is used in HTTP/1 CONNECT requests.
+fn authority_form(uri: &mut Uri) {
+    *uri = match uri.authority() {
+        Some(auth) => {
+            let mut parts = ::http::uri::Parts::default();
+            parts.authority = Some(auth.clone());
+            Uri::from_parts(parts).expect("authority is valid")
+        }
+        None => {
+            unreachable!("authority_form with relative uri");
+        }
+    };
+}
+
+fn absolute_form(uri: &mut Uri) {
+    debug_assert!(uri.scheme().is_some(), "absolute_form needs a scheme");
+    debug_assert!(
+        uri.authority().is_some(),
+        "absolute_form needs an authority"
+    );
+}
+
+/// Convert the URI to origin-form, if it is not already.
+///
+/// This form of the URI has no scheme or authority, and contains just
+/// the path, usually used in HTTP/1 requests.
+fn origin_form(uri: &mut Uri) {
+    let path = match uri.path_and_query() {
+        Some(path) if path.as_str() != "/" => {
+            let mut parts = ::http::uri::Parts::default();
+            parts.path_and_query = Some(path.clone());
+            Uri::from_parts(parts).expect("path is valid uri")
+        }
+        _none_or_just_slash => {
+            debug_assert!(Uri::default() == "/");
+            Uri::default()
+        }
+    };
+    *uri = path
+}
+
+/// Returns the port if it is not the default port for the scheme.
+fn get_non_default_port(uri: &Uri) -> Option<Port<&str>> {
+    match (uri.port().map(|p| p.as_u16()), is_schema_secure(uri)) {
+        (Some(443), true) => None,
+        (Some(80), false) => None,
+        _ => uri.port(),
+    }
+}
+
+/// Returns true if the URI scheme is presumed secure.
+fn is_schema_secure(uri: &Uri) -> bool {
+    uri.scheme_str()
+        .map(|scheme_str| matches!(scheme_str, "wss" | "https"))
+        .unwrap_or_default()
+}
+
+/// Set the Host header on the request if it is not already set,
+/// using the authority from the URI.
+fn set_host_header<B>(request: &mut http::Request<B>) {
+    let uri = request.uri().clone();
+    request
+        .headers_mut()
+        .entry(http::header::HOST)
+        .or_insert_with(|| {
+            let hostname = uri.host().expect("authority implies host");
+            if let Some(port) = get_non_default_port(&uri) {
+                let s = format!("{}:{}", hostname, port);
+                HeaderValue::from_str(&s)
+            } else {
+                HeaderValue::from_str(hostname)
+            }
+            .expect("uri host is valid header value")
+        });
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[cfg(feature = "mocks")]
+    use crate::Body;
+
+    #[cfg(feature = "mocks")]
+    use crate::client::conn::protocol::mock::MockProtocol;
+    #[cfg(feature = "mocks")]
+    use crate::client::conn::transport::mock::{MockConnectionError, MockTransport};
+
+    use crate::client::pool::Config as PoolConfig;
+
+    use super::*;
+
+    #[test]
+    fn test_set_host_header() {
+        let mut request = http::Request::new(());
+        *request.uri_mut() = "http://example.com".parse().unwrap();
+        set_host_header(&mut request);
+        assert_eq!(
+            request.headers().get(http::header::HOST).unwrap(),
+            "example.com"
+        );
+
+        let mut request = http::Request::new(());
+        *request.uri_mut() = "http://example.com:8080".parse().unwrap();
+        set_host_header(&mut request);
+        assert_eq!(
+            request.headers().get(http::header::HOST).unwrap(),
+            "example.com:8080"
+        );
+
+        let mut request = http::Request::new(());
+        *request.uri_mut() = "https://example.com".parse().unwrap();
+        set_host_header(&mut request);
+        assert_eq!(
+            request.headers().get(http::header::HOST).unwrap(),
+            "example.com"
+        );
+
+        let mut request = http::Request::new(());
+        *request.uri_mut() = "https://example.com:8443".parse().unwrap();
+        set_host_header(&mut request);
+        assert_eq!(
+            request.headers().get(http::header::HOST).unwrap(),
+            "example.com:8443"
+        );
+    }
+
+    #[test]
+    fn test_is_schema_secure() {
+        let uri = "http://example.com".parse().unwrap();
+        assert!(!is_schema_secure(&uri));
+
+        let uri = "https://example.com".parse().unwrap();
+        assert!(is_schema_secure(&uri));
+
+        let uri = "ws://example.com".parse().unwrap();
+        assert!(!is_schema_secure(&uri));
+
+        let uri = "wss://example.com".parse().unwrap();
+        assert!(is_schema_secure(&uri));
+    }
+
+    #[test]
+    fn test_get_non_default_port() {
+        let uri = "http://example.com".parse().unwrap();
+        assert_eq!(get_non_default_port(&uri).map(|p| p.as_u16()), None);
+
+        let uri = "http://example.com:8080".parse().unwrap();
+        assert_eq!(get_non_default_port(&uri).map(|p| p.as_u16()), Some(8080));
+
+        let uri = "https://example.com".parse().unwrap();
+        assert_eq!(get_non_default_port(&uri).map(|p| p.as_u16()), None);
+
+        let uri = "https://example.com:8443".parse().unwrap();
+        assert_eq!(get_non_default_port(&uri).map(|p| p.as_u16()), Some(8443));
+    }
+
+    #[test]
+    fn test_origin_form() {
+        let mut uri = "http://example.com".parse().unwrap();
+        origin_form(&mut uri);
+        assert_eq!(uri, "/");
+
+        let mut uri = "/some/path/here".parse().unwrap();
+        origin_form(&mut uri);
+        assert_eq!(uri, "/some/path/here");
+
+        let mut uri = "http://example.com:8080/some/path?query#fragment"
+            .parse()
+            .unwrap();
+        origin_form(&mut uri);
+        assert_eq!(uri, "/some/path?query");
+
+        let mut uri = "/".parse().unwrap();
+        origin_form(&mut uri);
+        assert_eq!(uri, "/");
+    }
+
+    #[test]
+    fn test_absolute_form() {
+        let mut uri = "http://example.com".parse().unwrap();
+        absolute_form(&mut uri);
+        assert_eq!(uri, "http://example.com");
+
+        let mut uri = "http://example.com:8080".parse().unwrap();
+        absolute_form(&mut uri);
+        assert_eq!(uri, "http://example.com:8080");
+
+        let mut uri = "https://example.com/some/path?query".parse().unwrap();
+        absolute_form(&mut uri);
+        assert_eq!(uri, "https://example.com/some/path?query");
+
+        let mut uri = "https://example.com:8443".parse().unwrap();
+        absolute_form(&mut uri);
+        assert_eq!(uri, "https://example.com:8443");
+
+        let mut uri = "http://example.com:443".parse().unwrap();
+        absolute_form(&mut uri);
+        assert_eq!(uri, "http://example.com:443");
+
+        let mut uri = "https://example.com:80".parse().unwrap();
+        absolute_form(&mut uri);
+        assert_eq!(uri, "https://example.com:80");
+    }
+
+    #[cfg(feature = "mocks")]
+    #[tokio::test]
+    async fn test_client_mock_transport() {
+        let transport = MockTransport::new(false);
+        let protocol = MockProtocol;
+        let pool = PoolConfig::default();
+
+        let client: ClientService<MockTransport, MockProtocol, Body> =
+            ClientService::new(transport, protocol, pool);
+
+        client
+            .request(
+                http::Request::builder()
+                    .uri("mock://somewhere")
+                    .body(crate::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[cfg(feature = "mocks")]
+    #[tokio::test]
+    async fn test_client_mock_connection_error() {
+        let transport = MockTransport::connection_error();
+        let protocol = MockProtocol;
+        let pool = PoolConfig::default();
+
+        let client: ClientService<MockTransport, MockProtocol, Body> =
+            ClientService::new(transport, protocol, pool);
+
+        let result = client
+            .request(
+                http::Request::builder()
+                    .uri("mock://somewhere")
+                    .body(crate::Body::empty())
+                    .unwrap(),
+            )
+            .await;
+
+        let err = result.unwrap_err();
+
+        let Error::Connection(err) = err else {
+            panic!("unexpected error: {:?}", err);
+        };
+
+        let err = err.downcast::<ConnectionError>().unwrap();
+
+        let ConnectionError::Connecting(err) = *err else {
+            panic!("unexpected error: {:?}", err);
+        };
+
+        err.downcast::<MockConnectionError>().unwrap();
+    }
+}

--- a/src/client/service.rs
+++ b/src/client/service.rs
@@ -329,8 +329,11 @@ fn prepare_request<C: Connection + PoolableConnection>(
         });
 
     if conn.version() == Version::HTTP_11 {
-        if request.version() == Version::HTTP_2 {
-            warn!("refusing to send HTTP/2 request to HTTP/1.1 connection");
+        if request.version() == Version::HTTP_2 || request.version() == Version::HTTP_3 {
+            warn!(
+                "refusing to send {:?} request to HTTP/1.1 connection",
+                request.version()
+            );
             return Err(Error::UnsupportedProtocol);
         }
 
@@ -354,7 +357,7 @@ fn prepare_request<C: Connection + PoolableConnection>(
     } else if request.method() == http::Method::CONNECT {
         return Err(Error::InvalidMethod(http::Method::CONNECT));
     } else if conn.version() == Version::HTTP_2 {
-        set_host_header(request);
+        *request.version_mut() = Version::HTTP_2;
     }
     Ok(())
 }

--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -12,14 +12,10 @@ use std::sync::Arc;
 
 use crate::bridge::rt::TokioExecutor;
 #[cfg(feature = "client")]
-use crate::client::conn::protocol::auto::HttpConnectionBuilder;
-use crate::client::conn::transport::TransportExt as _;
+use crate::client::conn::protocol::auto;
+
 #[cfg(feature = "client")]
 use crate::client::conn::Stream as ClientStream;
-#[cfg(feature = "client")]
-use crate::client::conn::TlsTransport;
-#[cfg(feature = "client")]
-use crate::client::ClientService;
 use crate::pidfile::PidFile;
 use crate::server::AutoBuilder;
 
@@ -31,16 +27,12 @@ use tower::make::Shared;
 
 mod transport;
 
+use crate::client::Client;
 pub use transport::GrpcScheme;
 pub use transport::RegistryTransport;
 pub use transport::Scheme;
 pub use transport::SvcScheme;
 pub use transport::TransportBuilder;
-
-/// Service Registry client which will connect to internal services.
-pub type Client<B = crate::body::Body> = crate::client::Client<
-    ClientService<TlsTransport<transport::RegistryTransport>, HttpConnectionBuilder, B>,
->;
 
 /// An error occured while connecting to a service.
 #[derive(Debug, thiserror::Error)]
@@ -346,9 +338,15 @@ impl ServiceRegistry {
     }
 
     /// Create a client which will connect to internal services.
-    pub fn client<B>(&self) -> Client<B> {
-        let transport = self.default_transport().without_tls();
-        Client::new(Default::default(), transport, Default::default())
+    pub fn client(&self) -> Client {
+        let transport = self.default_transport();
+
+        Client::builder()
+            .with_transport(transport)
+            .with_protocol(auto::HttpConnectionBuilder::default())
+            .with_pool(Default::default())
+            .without_tls()
+            .build()
     }
 }
 

--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -18,6 +18,8 @@ use crate::client::conn::transport::TransportExt as _;
 use crate::client::conn::Stream as ClientStream;
 #[cfg(feature = "client")]
 use crate::client::conn::TlsTransport;
+#[cfg(feature = "client")]
+use crate::client::ClientService;
 use crate::pidfile::PidFile;
 use crate::server::AutoBuilder;
 
@@ -36,8 +38,9 @@ pub use transport::SvcScheme;
 pub use transport::TransportBuilder;
 
 /// Service Registry client which will connect to internal services.
-pub type Client<B = crate::body::Body> =
-    crate::client::Client<HttpConnectionBuilder, TlsTransport<transport::RegistryTransport>, B>;
+pub type Client<B = crate::body::Body> = crate::client::Client<
+    ClientService<TlsTransport<transport::RegistryTransport>, HttpConnectionBuilder, B>,
+>;
 
 /// An error occured while connecting to a service.
 #[derive(Debug, thiserror::Error)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! Building the missing middle for network services in Rust.
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 use std::fmt;
 
 use tracing::dispatcher;

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -5,6 +5,8 @@ mod http;
 #[cfg(feature = "incoming")]
 mod incoming;
 mod make;
+#[cfg(feature = "client")]
+mod retry;
 mod serviceref;
 mod shared;
 
@@ -14,6 +16,8 @@ pub use self::http::HttpService;
 #[cfg(feature = "incoming")]
 pub use self::incoming::{AdaptIncomingLayer, AdaptIncomingService};
 pub use self::make::{make_service_fn, BoxMakeServiceLayer, BoxMakeServiceRef, MakeServiceRef};
+#[cfg(feature = "client")]
+pub use self::retry::{Attempts, Retry, RetryLayer};
 pub use serviceref::ServiceRef;
 pub use shared::SharedService;
 pub use tower::{service_fn, Service, ServiceBuilder, ServiceExt};

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,5 +1,6 @@
 //! A collection of utilities for working with `Service` types and Servers.
 
+mod adapt;
 mod http;
 #[cfg(feature = "incoming")]
 mod incoming;
@@ -14,4 +15,3 @@ pub use self::incoming::{AdaptIncomingLayer, AdaptIncomingService};
 pub use self::make::{make_service_fn, BoxMakeServiceLayer, BoxMakeServiceRef, MakeServiceRef};
 pub use serviceref::ServiceRef;
 pub use tower::{service_fn, Service, ServiceBuilder, ServiceExt};
-mod adapt;

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -6,6 +6,7 @@ mod http;
 mod incoming;
 mod make;
 mod serviceref;
+mod shared;
 
 pub use self::adapt::{AdaptCustomBodyExt, AdaptCustomBodyLayer, AdaptCustomBodyService};
 pub use self::adapt::{AdaptOuterBodyLayer, AdaptOuterBodyService};
@@ -14,4 +15,5 @@ pub use self::http::HttpService;
 pub use self::incoming::{AdaptIncomingLayer, AdaptIncomingService};
 pub use self::make::{make_service_fn, BoxMakeServiceLayer, BoxMakeServiceRef, MakeServiceRef};
 pub use serviceref::ServiceRef;
+pub use shared::SharedService;
 pub use tower::{service_fn, Service, ServiceBuilder, ServiceExt};

--- a/src/service/retry.rs
+++ b/src/service/retry.rs
@@ -1,0 +1,51 @@
+use tower::retry::Policy;
+
+pub use tower::retry::{Retry, RetryLayer};
+
+/// A policy for retrying requests.
+#[derive(Debug, Clone)]
+pub struct Attempts(usize);
+
+impl Attempts {
+    /// Create a new policy that will retry a request `attempts` times.
+    pub fn new(attempts: usize) -> Self {
+        Self(attempts)
+    }
+}
+
+impl<E> Policy<http::Request<crate::Body>, http::Response<crate::Body>, E> for Attempts {
+    type Future = std::future::Ready<Self>;
+
+    fn retry(
+        &self,
+        _req: &http::Request<crate::Body>,
+        result: Result<&http::Response<crate::Body>, &E>,
+    ) -> Option<Self::Future> {
+        match result {
+            Ok(res) if res.status().is_server_error() => Some(std::future::ready(Self(self.0 - 1))),
+            Ok(_) => None,
+            Err(_) if self.0 > 0 => Some(std::future::ready(Self(self.0 - 1))),
+            Err(_) => None,
+        }
+    }
+
+    fn clone_request(
+        &self,
+        req: &http::Request<crate::Body>,
+    ) -> Option<http::Request<crate::Body>> {
+        if let Some(body) = req.body().try_clone() {
+            let mut new_req = http::Request::builder()
+                .uri(req.uri().clone())
+                .method(req.method().clone())
+                .version(req.version());
+
+            if let Some(headers) = new_req.headers_mut() {
+                *headers = req.headers().clone();
+            };
+
+            new_req.body(body).ok()
+        } else {
+            None
+        }
+    }
+}

--- a/src/service/shared.rs
+++ b/src/service/shared.rs
@@ -1,0 +1,101 @@
+use std::fmt;
+
+use futures_core::future::BoxFuture;
+use tower::{Service, ServiceExt};
+
+/// A [`Service`] that can be cloned, sent, and shared across threads.
+pub struct SharedService<T, U, E>(
+    Box<
+        dyn CloneService<T, Response = U, Error = E, Future = BoxFuture<'static, Result<U, E>>>
+            + Send
+            + Sync
+            + 'static,
+    >,
+);
+
+impl<T, U, E> SharedService<T, U, E> {
+    /// Create a new `SharedService` from a `Service`.
+    pub fn new<S>(service: S) -> Self
+    where
+        S: Service<T, Response = U, Error = E> + Clone + Send + Sync + 'static,
+        S::Future: Send + 'static,
+    {
+        Self(Box::new(service.map_future(|f| Box::pin(f) as _)))
+    }
+
+    /// Create a layer which wraps a `Service` in a `SharedService`.
+    pub fn layer<S>() -> impl tower::layer::Layer<S, Service = SharedService<T, U, E>>
+    where
+        S: Service<T, Response = U, Error = E> + Clone + Send + Sync + 'static,
+        S::Future: Send + 'static,
+    {
+        tower::layer::layer_fn(Self::new)
+    }
+}
+
+impl<T, U, E> Service<T> for SharedService<T, U, E> {
+    type Response = U;
+
+    type Error = E;
+
+    type Future = BoxFuture<'static, Result<U, E>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.0.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: T) -> Self::Future {
+        self.0.call(req)
+    }
+}
+
+impl<T, U, E> Clone for SharedService<T, U, E> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone_box())
+    }
+}
+
+trait CloneService<R>: Service<R> {
+    fn clone_box(
+        &self,
+    ) -> Box<
+        dyn CloneService<R, Response = Self::Response, Error = Self::Error, Future = Self::Future>
+            + Send
+            + Sync
+            + 'static,
+    >;
+}
+
+impl<R, T> CloneService<R> for T
+where
+    T: Service<R> + Clone + Send + Sync + 'static,
+{
+    fn clone_box(
+        &self,
+    ) -> Box<
+        dyn CloneService<R, Response = T::Response, Error = T::Error, Future = T::Future>
+            + Send
+            + Sync
+            + 'static,
+    > {
+        Box::new(self.clone())
+    }
+}
+
+impl<T, U, E> fmt::Debug for SharedService<T, U, E> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("SharedService").finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(SharedService<http::Request<crate::Body>, http::Response<crate::Body>, Box<dyn std::error::Error + Send + Sync + 'static>>: Clone, Send, Sync);
+}

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -66,7 +66,13 @@ async fn service_ok(
 ) -> Result<hyperdriver::body::Response, BoxError> {
     Ok(http::response::Builder::new()
         .status(200)
-        .header("O-Host", req.headers().get("Host").unwrap())
+        .header(
+            "O-Host",
+            req.headers()
+                .get("Host")
+                .and_then(|h| h.to_str().ok())
+                .unwrap_or("missing"),
+        )
         .body(hyperdriver::body::Body::empty())?)
 }
 

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -18,7 +18,7 @@ async fn client() -> Result<(), BoxError> {
 
     let server = tokio::spawn(serve_one_h1(acceptor));
 
-    let client = hyperdriver::client::Client::new(
+    let mut client = hyperdriver::client::Client::new(
         HttpConnectionBuilder::default(),
         DuplexTransport::new(1024, tx.clone()),
         PoolConfig::default(),
@@ -42,7 +42,7 @@ async fn client_h2() -> Result<(), BoxError> {
 
     let server = tokio::spawn(serve_one_h2(acceptor));
 
-    let client = hyperdriver::client::Client::new(
+    let mut client = hyperdriver::client::Client::new(
         HttpConnectionBuilder::default(),
         DuplexTransport::new(1024, tx),
         PoolConfig::default(),

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -5,8 +5,8 @@ use hyperdriver::bridge::io::TokioIo;
 use hyperdriver::bridge::rt::TokioExecutor;
 use std::pin::pin;
 
+use hyperdriver::client::conn::protocol::auto::HttpConnectionBuilder;
 use hyperdriver::client::conn::transport::duplex::DuplexTransport;
-use hyperdriver::client::{conn::protocol::auto::HttpConnectionBuilder, PoolConfig};
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 #[tokio::test]
@@ -18,11 +18,11 @@ async fn client() -> Result<(), BoxError> {
 
     let server = tokio::spawn(serve_one_h1(acceptor));
 
-    let mut client = hyperdriver::client::Client::new(
-        HttpConnectionBuilder::default(),
-        DuplexTransport::new(1024, tx.clone()),
-        PoolConfig::default(),
-    );
+    let client = hyperdriver::client::Client::builder()
+        .with_protocol(HttpConnectionBuilder::default())
+        .with_transport(DuplexTransport::new(1024, tx.clone()))
+        .with_default_pool()
+        .build();
 
     let resp: Response = client.get("http://test/".parse().unwrap()).await?;
 
@@ -42,11 +42,11 @@ async fn client_h2() -> Result<(), BoxError> {
 
     let server = tokio::spawn(serve_one_h2(acceptor));
 
-    let mut client = hyperdriver::client::Client::new(
-        HttpConnectionBuilder::default(),
-        DuplexTransport::new(1024, tx),
-        PoolConfig::default(),
-    );
+    let client = hyperdriver::client::Client::builder()
+        .with_protocol(HttpConnectionBuilder::default())
+        .with_transport(DuplexTransport::new(1024, tx))
+        .with_default_pool()
+        .build();
 
     let request = http::Request::get("http://test/")
         .version(http::Version::HTTP_2)

--- a/tests/httpbin.rs
+++ b/tests/httpbin.rs
@@ -10,7 +10,7 @@ async fn httpbin_request(
         ..Default::default()
     };
 
-    let client = Client::builder()
+    let mut client = Client::builder()
         .with_tcp(config)
         .with_default_tls()
         .build();

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -43,7 +43,7 @@ async fn connection<P: hyperdriver::client::conn::Protocol<Stream>>(
 
 fn hello_world() -> hyperdriver::body::Request {
     http::Request::builder()
-        .uri("/")
+        .uri("https://localhost/hello")
         .body(hyperdriver::body::Body::from("hello world"))
         .unwrap()
 }

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -105,11 +105,12 @@ async fn tls_echo_h1() {
         .with_no_client_auth();
     client_tls.alpn_protocols.push(b"http/1.1".to_vec());
 
-    let mut client = Client::new(
-        Builder::new(),
-        DuplexTransport::new(1024, duplex_client).with_tls(client_tls.into()),
-        Default::default(),
-    );
+    let client = Client::builder()
+        .with_protocol(Builder::new())
+        .with_default_pool()
+        .with_transport(DuplexTransport::new(1024, duplex_client))
+        .with_tls(client_tls)
+        .build();
 
     let response: Response<hyperdriver::Body> = client
         .request(
@@ -154,11 +155,10 @@ async fn tls_echo_h2() {
         .with_no_client_auth();
     client_tls.alpn_protocols.push(b"h2".to_vec());
 
-    let mut client = Client::new(
-        Builder::new(TokioExecutor::new()),
-        DuplexTransport::new(1024, duplex_client).with_tls(client_tls.into()),
-        Default::default(),
-    );
+    let client = Client::builder()
+        .with_protocol(Builder::new(TokioExecutor::new()))
+        .with_transport(DuplexTransport::new(1024, duplex_client).with_tls(client_tls.into()))
+        .build();
 
     let response: Response<hyperdriver::Body> = client
         .request(

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -105,7 +105,7 @@ async fn tls_echo_h1() {
         .with_no_client_auth();
     client_tls.alpn_protocols.push(b"http/1.1".to_vec());
 
-    let client = Client::new(
+    let mut client = Client::new(
         Builder::new(),
         DuplexTransport::new(1024, duplex_client).with_tls(client_tls.into()),
         Default::default(),
@@ -154,7 +154,7 @@ async fn tls_echo_h2() {
         .with_no_client_auth();
     client_tls.alpn_protocols.push(b"h2".to_vec());
 
-    let client = Client::new(
+    let mut client = Client::new(
         Builder::new(TokioExecutor::new()),
         DuplexTransport::new(1024, duplex_client).with_tls(client_tls.into()),
         Default::default(),


### PR DESCRIPTION
Refactor the Client to be a tower::Service internally.

This takes advantage of the `tower::Service` trait and related ecosystem
to provide additional helpers and middleware when using a `Client`.
