### PR TITLE
Common error type for client services

### DIFF
--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -33,6 +33,10 @@ pub enum Error {
     /// Protocol is not supported by this client or transport.
     #[error("unsupported protocol")]
     UnsupportedProtocol,
+
+    /// Request timeout
+    #[error("request timeout")]
+    RequestTimeout,
 }
 
 impl From<pool::Error<ConnectionError>> for Error {
@@ -47,136 +51,12 @@ impl From<pool::Error<ConnectionError>> for Error {
     }
 }
 
-fn try_downcast<T, K>(k: K) -> Result<T, K>
-where
-    T: 'static,
-    K: 'static,
-{
-    let mut k = Some(k);
-    if let Some(k) = <dyn std::any::Any>::downcast_mut::<Option<T>>(&mut k) {
-        Ok(k.take().unwrap())
-    } else {
-        Err(k.unwrap())
-    }
-}
+#[cfg(test)]
+mod tests {
 
-impl Error {
-    pub(crate) fn downcast(error: BoxError) -> Self {
-        let error = match try_downcast::<Self, BoxError>(error) {
-            Ok(error) => return error,
-            Err(error) => error,
-        };
+    use super::*;
 
-        let error = match try_downcast::<ConnectionError, BoxError>(error) {
-            Ok(error) => return Error::Connection(error.into()),
-            Err(error) => error,
-        };
+    use static_assertions::assert_impl_all;
 
-        let error = match try_downcast::<pool::Error<ConnectionError>, BoxError>(error) {
-            Ok(error) => return error.into(),
-            Err(error) => error,
-        };
-
-        let error = match try_downcast::<hyper::Error, BoxError>(error) {
-            Ok(error) => return Error::User(error),
-            Err(error) => error,
-        };
-
-        Error::Service(error)
-    }
-}
-
-/// A middleware that downcasts errors to `Error`.
-#[derive(Debug, Clone)]
-pub struct DowncastError<S> {
-    inner: S,
-}
-
-impl<S> DowncastError<S> {
-    /// Create a new DowncastError service.
-    pub fn new(inner: S) -> Self {
-        Self { inner }
-    }
-}
-
-impl<S, R> tower::Service<R> for DowncastError<S>
-where
-    S: tower::Service<R, Error = BoxError>,
-{
-    type Response = S::Response;
-    type Error = Error;
-    type Future = future::DowncastErrorFuture<S::Future>;
-
-    fn poll_ready(
-        &mut self,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), Self::Error>> {
-        self.inner
-            .poll_ready(cx)
-            .map(|r| r.map_err(Error::downcast))
-    }
-
-    fn call(&mut self, req: R) -> Self::Future {
-        future::DowncastErrorFuture {
-            inner: self.inner.call(req),
-        }
-    }
-}
-
-mod future {
-    use core::fmt;
-    use std::future::Future;
-
-    use super::BoxError;
-
-    /// Future for the DowncastError middleware.
-    #[pin_project::pin_project]
-    pub struct DowncastErrorFuture<F> {
-        #[pin]
-        pub(super) inner: F,
-    }
-
-    impl<F> fmt::Debug for DowncastErrorFuture<F> {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            f.debug_struct("DowncastErrorFuture").finish()
-        }
-    }
-
-    impl<F, T> Future for DowncastErrorFuture<F>
-    where
-        F: Future<Output = Result<T, BoxError>>,
-    {
-        type Output = Result<T, super::Error>;
-
-        fn poll(
-            self: std::pin::Pin<&mut Self>,
-            cx: &mut std::task::Context<'_>,
-        ) -> std::task::Poll<Self::Output> {
-            self.project()
-                .inner
-                .poll(cx)
-                .map(|r| r.map_err(super::Error::downcast))
-        }
-    }
-}
-
-/// A layer that downcasts errors to `Error`.
-#[derive(Debug, Clone, Default)]
-pub struct DowncastErrorLayer {
-    _priv: (),
-}
-
-impl DowncastErrorLayer {
-    /// Create a new DowncastErrorLayer.
-    pub fn new() -> Self {
-        Self { _priv: () }
-    }
-}
-
-impl<S> tower::layer::Layer<S> for DowncastErrorLayer {
-    type Service = DowncastError<S>;
-
-    fn layer(&self, inner: S) -> Self::Service {
-        DowncastError::new(inner)
-    }
+    assert_impl_all!(Error: std::error::Error, Send, Sync, Into<Box<dyn std::error::Error + Send + Sync>>);
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -31,7 +31,6 @@ pub mod pool;
 mod service;
 
 pub use self::error::Error;
-pub use self::error::{DowncastError, DowncastErrorLayer};
 pub use self::pool::Config as PoolConfig;
 pub use builder::Builder;
 

--- a/src/client/pool/checkout.rs
+++ b/src/client/pool/checkout.rs
@@ -47,8 +47,13 @@ impl fmt::Display for CheckoutId {
 
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum Error<E> {
+    #[error("creating connection")]
     Connecting(#[source] E),
+
+    #[error("handshaking connection")]
     Handshaking(#[source] E),
+
+    #[error("connection closed")]
     Unavailable,
 }
 
@@ -361,6 +366,10 @@ impl<C: PoolableConnection, T: PoolableTransport, E> PinnedDrop for Checkout<C, 
 #[cfg(test)]
 mod test {
     use super::*;
+
+    use static_assertions::assert_impl_all;
+
+    assert_impl_all!(Error<std::io::Error>: std::error::Error, std::fmt::Debug, std::fmt::Display);
 
     #[cfg(feature = "mocks")]
     use crate::client::conn::transport::mock::MockTransport;

--- a/src/client/pool/checkout.rs
+++ b/src/client/pool/checkout.rs
@@ -369,7 +369,7 @@ mod test {
 
     use static_assertions::assert_impl_all;
 
-    assert_impl_all!(Error<std::io::Error>: std::error::Error, std::fmt::Debug, std::fmt::Display);
+    assert_impl_all!(Error<std::io::Error>: std::error::Error, Send, Sync, Into<Box<dyn std::error::Error + Send + Sync>>);
 
     #[cfg(feature = "mocks")]
     use crate::client::conn::transport::mock::MockTransport;

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -5,10 +5,12 @@ mod http;
 #[cfg(feature = "incoming")]
 mod incoming;
 mod make;
+mod option;
 #[cfg(feature = "client")]
 mod retry;
 mod serviceref;
 mod shared;
+mod timeout;
 
 pub use self::adapt::{AdaptCustomBodyExt, AdaptCustomBodyLayer, AdaptCustomBodyService};
 pub use self::adapt::{AdaptOuterBodyLayer, AdaptOuterBodyService};
@@ -18,6 +20,8 @@ pub use self::incoming::{AdaptIncomingLayer, AdaptIncomingService};
 pub use self::make::{make_service_fn, BoxMakeServiceLayer, BoxMakeServiceRef, MakeServiceRef};
 #[cfg(feature = "client")]
 pub use self::retry::{Attempts, Retry, RetryLayer};
+pub use option::{OptionLayer, OptionLayerExt, OptionService};
 pub use serviceref::ServiceRef;
 pub use shared::SharedService;
+pub use timeout::{Timeout, TimeoutLayer};
 pub use tower::{service_fn, Service, ServiceBuilder, ServiceExt};

--- a/src/service/option.rs
+++ b/src/service/option.rs
@@ -1,0 +1,150 @@
+use tower::layer::util::Stack;
+use tower::ServiceBuilder;
+
+/// Extends `ServiceBuilder` with an `optional` method.
+pub trait OptionLayerExt<S> {
+    /// Apply an optional middleware to the service, with a consistent concrete error type.
+    fn optional<T>(self, middleware: Option<T>) -> ServiceBuilder<Stack<OptionLayer<T>, S>>;
+}
+
+impl<S> OptionLayerExt<S> for ServiceBuilder<S> {
+    fn optional<T>(self, middleware: Option<T>) -> ServiceBuilder<Stack<OptionLayer<T>, S>> {
+        self.layer(OptionLayer::new(middleware))
+    }
+}
+
+/// A middleware for an optional layer.
+#[derive(Debug, Clone)]
+pub struct OptionLayer<M> {
+    middleware: Option<M>,
+}
+
+impl<M> OptionLayer<M> {
+    /// Create a new `OptionLayer` with the provided middleware layer.
+    pub fn new(middleware: Option<M>) -> Self {
+        Self { middleware }
+    }
+}
+
+impl<M, S> tower::Layer<S> for OptionLayer<M>
+where
+    M: tower::Layer<S>,
+{
+    type Service = OptionService<M::Service, S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        match self.middleware {
+            Some(ref middleware) => OptionService {
+                inner: OptionServiceState::Middleware(middleware.layer(inner)),
+            },
+            None => OptionService {
+                inner: OptionServiceState::Service(inner),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum OptionServiceState<M, S> {
+    Middleware(M),
+    Service(S),
+}
+
+/// A middleware for an optional layer with merged error types.
+///
+/// The `tower::util::Either` middleware converts errors to `BoxError`, which
+/// can make it difficult to return to a concrete error type. This middleware
+/// allows the inner service to return a concrete error type, while the optional
+/// middleware must return an error type that can be converted to the inner
+/// service's error type.
+#[derive(Clone, Debug)]
+pub struct OptionService<M, S> {
+    inner: OptionServiceState<M, S>,
+}
+
+impl<M, S, Req, E> tower::Service<Req> for OptionService<M, S>
+where
+    S: tower::Service<Req, Error = E>,
+    M: tower::Service<Req, Response = S::Response>,
+    M::Error: Into<E>,
+{
+    type Response = S::Response;
+    type Error = E;
+    type Future = self::future::OptionServiceFuture<M::Future, S::Future>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        match self.inner {
+            OptionServiceState::Middleware(ref mut m) => m.poll_ready(cx).map_err(Into::into),
+            OptionServiceState::Service(ref mut s) => s.poll_ready(cx),
+        }
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        match self.inner {
+            OptionServiceState::Middleware(ref mut m) => {
+                self::future::OptionServiceFuture::middleware(m.call(req))
+            }
+            OptionServiceState::Service(ref mut s) => {
+                self::future::OptionServiceFuture::service(s.call(req))
+            }
+        }
+    }
+}
+
+mod future {
+    use std::future::Future;
+
+    use pin_project::pin_project;
+
+    #[derive(Debug)]
+    #[pin_project(project = StateProj)]
+    enum State<M, S> {
+        Middleware(#[pin] M),
+        Service(#[pin] S),
+    }
+
+    #[derive(Debug)]
+    #[pin_project]
+    pub struct OptionServiceFuture<M, S> {
+        #[pin]
+        state: State<M, S>,
+    }
+
+    impl<M, S> OptionServiceFuture<M, S> {
+        pub(super) fn service(inner: S) -> Self {
+            Self {
+                state: State::Service(inner),
+            }
+        }
+
+        pub(super) fn middleware(inner: M) -> Self {
+            Self {
+                state: State::Middleware(inner),
+            }
+        }
+    }
+
+    impl<M, S, R, E, ME> Future for OptionServiceFuture<M, S>
+    where
+        M: Future<Output = Result<R, ME>>,
+        S: Future<Output = Result<R, E>>,
+        ME: Into<E>,
+    {
+        type Output = Result<R, E>;
+
+        fn poll(
+            self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Self::Output> {
+            match self.project().state.project() {
+                StateProj::Middleware(future) => {
+                    future.poll(cx).map(|result| result.map_err(Into::into))
+                }
+                StateProj::Service(future) => future.poll(cx),
+            }
+        }
+    }
+}

--- a/src/service/timeout.rs
+++ b/src/service/timeout.rs
@@ -1,0 +1,163 @@
+//! Middleware which applies a timeout to requests.
+//!
+//! Supports a custom error type.
+
+use std::time::Duration;
+
+/// Layer to apply a timeout to requests, with a custom error type.
+pub struct TimeoutLayer<E> {
+    error: Box<fn() -> E>,
+    timeout: Duration,
+}
+
+impl<E> TimeoutLayer<E> {
+    /// Create a new `TimeoutLayer` with the provided error function and timeout.
+    pub fn new(error: fn() -> E, timeout: Duration) -> Self {
+        Self {
+            error: Box::new(error),
+            timeout,
+        }
+    }
+}
+
+impl<E> Clone for TimeoutLayer<E> {
+    fn clone(&self) -> Self {
+        Self {
+            error: self.error.clone(),
+            timeout: self.timeout,
+        }
+    }
+}
+
+impl<E> std::fmt::Debug for TimeoutLayer<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TimeoutLayer")
+            .field("timeout", &self.timeout)
+            .finish()
+    }
+}
+
+impl<S, E> tower::layer::Layer<S> for TimeoutLayer<E> {
+    type Service = Timeout<S, E>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Timeout::new(inner, self.timeout, self.error.clone())
+    }
+}
+
+/// Applies a timeout to requests, with a custom error type.
+pub struct Timeout<S, E> {
+    inner: S,
+    timeout: Duration,
+    error: Box<fn() -> E>,
+}
+
+impl<S, E> Timeout<S, E> {
+    /// Create a new `Timeout` with the provided inner service, timeout, and error function.
+    pub fn new(inner: S, timeout: Duration, error: Box<fn() -> E>) -> Self {
+        Self {
+            inner,
+            timeout,
+            error,
+        }
+    }
+}
+
+impl<S, E> Clone for Timeout<S, E>
+where
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            timeout: self.timeout,
+            error: self.error.clone(),
+        }
+    }
+}
+
+impl<S, E> std::fmt::Debug for Timeout<S, E>
+where
+    S: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Timeout")
+            .field("inner", &self.inner)
+            .field("timeout", &self.timeout)
+            .finish()
+    }
+}
+
+impl<S, E, Req> tower::Service<Req> for Timeout<S, E>
+where
+    S: tower::Service<Req, Error = E>,
+{
+    type Response = S::Response;
+    type Error = E;
+    type Future = self::future::TimeoutFuture<S::Future, S::Response, E>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        self::future::TimeoutFuture::new(self.inner.call(req), self.error.clone(), self.timeout)
+    }
+}
+
+mod future {
+
+    use std::{future::Future, marker::PhantomData, task::Poll};
+
+    use pin_project::pin_project;
+
+    #[derive(Debug)]
+    #[pin_project]
+    pub struct TimeoutFuture<F, R, E> {
+        #[pin]
+        inner: F,
+        error: Box<fn() -> E>,
+        response: PhantomData<fn() -> R>,
+
+        #[pin]
+        timeout: tokio::time::Sleep,
+    }
+
+    impl<F, R, E> TimeoutFuture<F, R, E> {
+        pub fn new(inner: F, error: Box<fn() -> E>, timeout: std::time::Duration) -> Self {
+            Self {
+                inner,
+                error,
+                response: PhantomData,
+                timeout: tokio::time::sleep(timeout),
+            }
+        }
+    }
+
+    impl<F, R, E> Future for TimeoutFuture<F, R, E>
+    where
+        F: Future<Output = Result<R, E>>,
+    {
+        type Output = Result<R, E>;
+
+        fn poll(
+            self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> Poll<Self::Output> {
+            let this = self.project();
+
+            match this.inner.poll(cx) {
+                Poll::Ready(response) => return Poll::Ready(response),
+                Poll::Pending => {}
+            }
+
+            match this.timeout.poll(cx) {
+                Poll::Ready(()) => Poll::Ready(Err((this.error)())),
+                Poll::Pending => Poll::Pending,
+            }
+        }
+    }
+}


### PR DESCRIPTION
Converts client services to always return a concrete, common error type.

The default tower services use `Box<Error>` as the error type, but this is not
necessary or optimal in this case, so there are some forked versions of those
tower services added to `crate::service`.
