### PR TITLE
Wrap tokio::net::TcpStream to provide access to remote address

### DIFF
--- a/src/client/conn/stream/mod.rs
+++ b/src/client/conn/stream/mod.rs
@@ -199,6 +199,8 @@ where
 #[cfg(feature = "stream")]
 impl From<TcpStream> for Stream {
     fn from(stream: TcpStream) -> Self {
+        let stream = crate::stream::tcp::TcpStream::client(stream);
+
         Stream {
             inner: Braid::from(stream).into(),
         }

--- a/src/client/conn/stream/mod.rs
+++ b/src/client/conn/stream/mod.rs
@@ -220,7 +220,7 @@ impl From<DuplexStream> for Stream {
 impl From<UnixStream> for Stream {
     fn from(stream: UnixStream) -> Self {
         Stream {
-            inner: Braid::from(stream).into(),
+            inner: Braid::from(crate::stream::unix::UnixStream::client(stream)).into(),
         }
     }
 }

--- a/src/client/conn/stream/tls.rs
+++ b/src/client/conn/stream/tls.rs
@@ -9,12 +9,12 @@ use std::{future::Future, pin::Pin};
 
 use rustls::ClientConfig;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-use tokio::net::{TcpStream, ToSocketAddrs};
+use tokio::net::ToSocketAddrs;
 
 use crate::info::tls::HasTlsConnectionInfo;
-use crate::info::{ConnectionInfo, HasConnectionInfo};
-
 use crate::info::TlsConnectionInfo;
+use crate::info::{ConnectionInfo, HasConnectionInfo};
+use crate::stream::tcp::TcpStream;
 use crate::stream::tls::TlsHandshakeStream;
 
 // NOTE: Individual fields are Box'd to reduce the resulting stack size

--- a/src/client/conn/transport/mod.rs
+++ b/src/client/conn/transport/mod.rs
@@ -646,8 +646,8 @@ mod future {
 mod tests {
     use super::*;
 
+    use crate::stream::tcp::TcpStream;
     use static_assertions::assert_impl_all;
-    use tokio::net::TcpStream;
 
     assert_impl_all!(TransportStream<Stream>: HasTlsConnectionInfo, HasConnectionInfo);
     assert_impl_all!(TransportStream<Stream>: Send, Sync, Unpin);

--- a/src/server/conn/acceptor.rs
+++ b/src/server/conn/acceptor.rs
@@ -21,8 +21,6 @@ use crate::info::HasConnectionInfo;
 #[cfg(feature = "tls")]
 use crate::server::conn::tls::TlsAcceptor as RawTlsAcceptor;
 #[cfg(feature = "stream")]
-use crate::stream::tcp::TcpStream;
-#[cfg(feature = "stream")]
 use crate::stream::{duplex::DuplexIncoming, Braid};
 
 /// Accept incoming connections for streams which might
@@ -159,15 +157,15 @@ impl Accept for AcceptorCore {
         cx: &mut Context,
     ) -> Poll<Result<Self::Conn, Self::Error>> {
         match self.project() {
-            AcceptorProj::Tcp(acceptor) => acceptor.poll_accept(cx).map(|stream| {
-                stream.map(|(stream, addr)| Braid::Tcp(TcpStream::server(stream, addr)))
-            }),
+            AcceptorProj::Tcp(acceptor) => acceptor
+                .poll_accept(cx)
+                .map(|stream| stream.map(Braid::Tcp)),
             AcceptorProj::Duplex(acceptor) => {
                 acceptor.poll_accept(cx).map_ok(|stream| stream.into())
             }
             AcceptorProj::Unix(acceptor) => acceptor
                 .poll_accept(cx)
-                .map(|stream| stream.map(|(stream, _address)| stream.into())),
+                .map(|stream| stream.map(Braid::Unix)),
         }
     }
 }

--- a/src/server/conn/stream.rs
+++ b/src/server/conn/stream.rs
@@ -8,16 +8,14 @@ use std::io;
 use std::task::{Context, Poll};
 use std::{future::Future, pin::Pin};
 
-use pin_project::pin_project;
-use tokio::io::{AsyncRead, AsyncWrite};
-#[cfg(feature = "stream")]
-use tokio::net::UnixStream;
-
-use crate::info::{ConnectionInfo, HasConnectionInfo};
+use crate::info::ConnectionInfo;
+use crate::info::HasConnectionInfo;
 #[cfg(feature = "stream")]
 use crate::stream::duplex::DuplexStream;
 #[cfg(feature = "stream")]
 use crate::stream::Braid;
+use pin_project::pin_project;
+use tokio::io::{AsyncRead, AsyncWrite};
 
 #[cfg(feature = "tls")]
 use crate::info::tls::TlsConnectionInfoReciever;
@@ -216,18 +214,6 @@ where
 #[cfg(feature = "stream")]
 impl From<DuplexStream> for Stream {
     fn from(stream: DuplexStream) -> Self {
-        Stream {
-            info: stream.info().map(Into::into),
-            #[cfg(feature = "tls")]
-            tls: TlsConnectionInfoReciever::empty(),
-            inner: Braid::from(stream).into(),
-        }
-    }
-}
-
-#[cfg(feature = "stream")]
-impl From<UnixStream> for Stream {
-    fn from(stream: UnixStream) -> Self {
         Stream {
             info: stream.info().map(Into::into),
             #[cfg(feature = "tls")]

--- a/src/server/conn/stream.rs
+++ b/src/server/conn/stream.rs
@@ -11,7 +11,7 @@ use std::{future::Future, pin::Pin};
 use pin_project::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite};
 #[cfg(feature = "stream")]
-use tokio::net::{TcpStream, UnixStream};
+use tokio::net::UnixStream;
 
 use crate::info::{ConnectionInfo, HasConnectionInfo};
 #[cfg(feature = "stream")]
@@ -209,18 +209,6 @@ where
             info: stream.info(),
             tls: stream.rx.clone(),
             inner: TlsBraid::Tls(stream),
-        }
-    }
-}
-
-#[cfg(feature = "stream")]
-impl From<TcpStream> for Stream {
-    fn from(stream: TcpStream) -> Self {
-        Stream {
-            info: stream.info().map(Into::into),
-            #[cfg(feature = "tls")]
-            tls: TlsConnectionInfoReciever::empty(),
-            inner: Braid::from(stream).into(),
         }
     }
 }

--- a/src/stream/core.rs
+++ b/src/stream/core.rs
@@ -4,12 +4,12 @@ use std::pin::pin;
 
 use pin_project::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::net::UnixStream;
 
 use crate::info::BraidAddr;
 use crate::info::{ConnectionInfo, HasConnectionInfo};
 use crate::stream::duplex::DuplexStream;
 use crate::stream::tcp::TcpStream;
+use crate::stream::unix::UnixStream;
 
 /// Dispatching wrapper for potential stream connection types
 ///

--- a/src/stream/core.rs
+++ b/src/stream/core.rs
@@ -4,12 +4,12 @@ use std::pin::pin;
 
 use pin_project::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::net::{TcpStream, UnixStream};
-
-use crate::info::{ConnectionInfo, HasConnectionInfo};
-use crate::stream::duplex::DuplexStream;
+use tokio::net::UnixStream;
 
 use crate::info::BraidAddr;
+use crate::info::{ConnectionInfo, HasConnectionInfo};
+use crate::stream::duplex::DuplexStream;
+use crate::stream::tcp::TcpStream;
 
 /// Dispatching wrapper for potential stream connection types
 ///

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -8,6 +8,7 @@ pub mod duplex;
 pub mod tcp;
 #[cfg(feature = "tls")]
 pub mod tls;
+pub mod unix;
 
 #[cfg(feature = "stream")]
 pub use core::Braid;

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -5,12 +5,11 @@
 #[cfg(feature = "stream")]
 mod core;
 pub mod duplex;
-
+pub mod tcp;
 #[cfg(feature = "tls")]
 pub mod tls;
 
 #[cfg(feature = "stream")]
 pub use core::Braid;
-
 #[cfg(feature = "tls")]
 pub use tls::TlsBraid;

--- a/src/stream/tcp.rs
+++ b/src/stream/tcp.rs
@@ -1,0 +1,187 @@
+//! TCP Stream implementation with better address semantics for servers.
+//!
+//! This module provides a `TcpStream` type that wraps `tokio::net::TcpStream` with
+//! better address semantics for servers. When a server accepts a connection, it
+//! returns the associated `SocketAddr` along side the stream. On some platforms,
+//! this information is not available after the connection is established via
+//! `TcpStream::peer_addr`. This module provides a way to retain this information
+//! for the lifetime of the stream.
+
+use std::fmt;
+use std::io;
+use std::net::SocketAddr;
+use std::ops::Deref;
+use std::ops::DerefMut;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::ToSocketAddrs;
+
+use crate::info::HasConnectionInfo;
+
+/// A TCP Stream, wrapping `tokio::net::TcpStream` with better
+/// address semantics for servers.
+#[pin_project::pin_project]
+pub struct TcpStream {
+    #[pin]
+    stream: tokio::net::TcpStream,
+    remote: Option<SocketAddr>,
+}
+
+impl fmt::Debug for TcpStream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.stream.fmt(f)
+    }
+}
+
+impl TcpStream {
+    /// Connect to a remote address. See `tokio::net::TcpStream::connect`.
+    pub async fn connect<A: ToSocketAddrs>(addr: A) -> io::Result<Self> {
+        let stream = tokio::net::TcpStream::connect(addr).await?;
+        Ok(Self::client(stream))
+    }
+
+    /// Create a new `TcpStream` from an existing `tokio::net::TcpStream` for a client
+    /// connection. Client connections should have valid `peer_addr` and `local_addr`.
+    pub fn client(inner: tokio::net::TcpStream) -> Self {
+        Self {
+            stream: inner,
+            remote: None,
+        }
+    }
+
+    /// Create a new `TcpStream` from an existing `tokio::net::TcpStream` for a server
+    /// connection. Server connections should have a valid `local_addr` but may not have a
+    /// `peer_addr`, hence the remote address must be provided.
+    pub fn server(inner: tokio::net::TcpStream, remote: SocketAddr) -> Self {
+        Self {
+            stream: inner,
+            remote: Some(remote),
+        }
+    }
+
+    /// Remote address of the connection. See `tokio::net::TcpStream::peer_addr`.
+    ///
+    /// For servers, this will return the remote address provided when creating the stream,
+    /// instead of an `io::Error`.
+    pub fn peer_addr(&self) -> io::Result<SocketAddr> {
+        match self.remote {
+            Some(addr) => Ok(addr),
+            None => self.stream.peer_addr(),
+        }
+    }
+
+    /// Unwraps the `TcpStream`, returning the inner `tokio::net::TcpStream`.
+    pub fn into_inner(self) -> tokio::net::TcpStream {
+        self.stream
+    }
+}
+
+impl Deref for TcpStream {
+    type Target = tokio::net::TcpStream;
+    fn deref(&self) -> &Self::Target {
+        &self.stream
+    }
+}
+
+impl DerefMut for TcpStream {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.stream
+    }
+}
+
+impl HasConnectionInfo for TcpStream {
+    type Addr = SocketAddr;
+    fn info(&self) -> crate::info::ConnectionInfo<Self::Addr> {
+        let remote_addr = match self.remote {
+            Some(addr) => addr,
+            None => self
+                .stream
+                .peer_addr()
+                .expect("peer_addr is available for stream"),
+        };
+
+        crate::info::ConnectionInfo {
+            local_addr: self
+                .stream
+                .local_addr()
+                .expect("local_addr is available for stream"),
+            remote_addr,
+            buffer_size: None,
+        }
+    }
+}
+
+impl AsyncRead for TcpStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        self.project().stream.poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for TcpStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        self.project().stream.poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        self.project().stream.poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        self.project().stream.poll_shutdown(cx)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<Result<usize, io::Error>> {
+        self.project().stream.poll_write_vectored(cx, bufs)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.stream.is_write_vectored()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::info::HasConnectionInfo as _;
+
+    use super::TcpStream;
+
+    #[tokio::test]
+    async fn test_tcp_streams() {
+        let listener = tokio::net::TcpListener::bind("0:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (stream, remote) = listener.accept().await.unwrap();
+
+            let stream = TcpStream::server(stream, remote);
+            let addr = stream.peer_addr().unwrap();
+            assert_eq!(addr, remote);
+            let addr = stream.info().remote_addr;
+            assert_eq!(addr, remote);
+        });
+
+        let client = tokio::spawn(async move {
+            let stream = TcpStream::connect(addr).await.unwrap();
+            let peer = stream.peer_addr().unwrap();
+            assert_eq!(addr.port(), peer.port());
+        });
+
+        let (s, c) = tokio::join!(server, client);
+        s.unwrap();
+        c.unwrap();
+    }
+}

--- a/src/stream/unix.rs
+++ b/src/stream/unix.rs
@@ -1,0 +1,180 @@
+//! Unix Stream implementation with better address semantics for servers.
+//!
+//! This module provides a `UnixStream` type that wraps `tokio::net::UnixStream` with
+//! better address semantics for servers. When a server accepts a connection, it
+//! returns the associated `SocketAddr` along side the stream. On some platforms,
+//! this information is not available after the connection is established via
+//! `UnixStream::peer_addr`. This module provides a way to retain this information
+//! for the lifetime of the stream.
+
+use std::fmt;
+use std::io;
+use std::ops::Deref;
+use std::ops::DerefMut;
+use std::path::Path;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncRead, AsyncWrite};
+#[cfg(all(feature = "server", feature = "stream"))]
+use tokio::net::UnixListener;
+
+use crate::info::HasConnectionInfo;
+use crate::info::UnixAddr;
+#[cfg(all(feature = "server", feature = "stream"))]
+use crate::server::Accept;
+
+/// A Unix Stream, wrapping `tokio::net::UnixStream` with better
+/// address semantics for servers.
+#[pin_project::pin_project]
+pub struct UnixStream {
+    #[pin]
+    stream: tokio::net::UnixStream,
+    remote: Option<UnixAddr>,
+}
+
+impl fmt::Debug for UnixStream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.stream.fmt(f)
+    }
+}
+
+impl UnixStream {
+    /// Connect to a remote address. See `tokio::net::UnixStream::connect`.
+    pub async fn connect<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        let stream = tokio::net::UnixStream::connect(path).await?;
+        Ok(Self::client(stream))
+    }
+
+    /// Create a pair of connected `UnixStream`s. See `tokio::net::UnixStream::pair`.
+    pub fn pair() -> io::Result<(Self, Self)> {
+        let (a, b) = tokio::net::UnixStream::pair()?;
+        Ok((
+            Self::server(a, UnixAddr::unnamed()),
+            Self::server(b, UnixAddr::unnamed()),
+        ))
+    }
+
+    /// Create a new `UnixStream` from an existing `tokio::net::UnixStream` for a client
+    /// connection. Client connections should have valid `peer_addr` and `local_addr`.
+    pub fn client(inner: tokio::net::UnixStream) -> Self {
+        Self {
+            stream: inner,
+            remote: None,
+        }
+    }
+
+    /// Create a new `UnixStream` from an existing `tokio::net::UnixStream` for a server
+    /// connection. Server connections should have a valid `local_addr` but may not have a
+    /// `peer_addr`, hence the remote address must be provided.
+    pub fn server(inner: tokio::net::UnixStream, remote: UnixAddr) -> Self {
+        Self {
+            stream: inner,
+            remote: Some(remote),
+        }
+    }
+
+    /// Local address of the connection. See `tokio::net::UnixStream::local_addr`.
+    pub fn local_addr(&self) -> io::Result<UnixAddr> {
+        self.stream.local_addr().and_then(UnixAddr::try_from)
+    }
+
+    /// Remote address of the connection. See `tokio::net::UnixStream::peer_addr`.
+    ///
+    /// For servers, this will return the remote address provided when creating the stream,
+    /// instead of an `io::Error`.
+    pub fn peer_addr(&self) -> io::Result<UnixAddr> {
+        match &self.remote {
+            Some(addr) => Ok(addr.clone()),
+            None => self.stream.peer_addr().and_then(UnixAddr::try_from),
+        }
+    }
+
+    /// Unwraps the `UnixStream`, returning the inner `tokio::net::UnixStream`.
+    pub fn into_inner(self) -> tokio::net::UnixStream {
+        self.stream
+    }
+}
+
+impl Deref for UnixStream {
+    type Target = tokio::net::UnixStream;
+    fn deref(&self) -> &Self::Target {
+        &self.stream
+    }
+}
+
+impl DerefMut for UnixStream {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.stream
+    }
+}
+
+impl HasConnectionInfo for UnixStream {
+    type Addr = UnixAddr;
+    fn info(&self) -> crate::info::ConnectionInfo<Self::Addr> {
+        let remote_addr = self
+            .peer_addr()
+            .expect("peer_addr is available for unix stream");
+        let local_addr = self
+            .local_addr()
+            .expect("local_addr is available for unix stream");
+
+        crate::info::ConnectionInfo {
+            local_addr,
+            remote_addr,
+            buffer_size: None,
+        }
+    }
+}
+
+impl AsyncRead for UnixStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        self.project().stream.poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for UnixStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        self.project().stream.poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        self.project().stream.poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        self.project().stream.poll_shutdown(cx)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<Result<usize, io::Error>> {
+        self.project().stream.poll_write_vectored(cx, bufs)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.stream.is_write_vectored()
+    }
+}
+
+#[cfg(all(feature = "server", feature = "stream"))]
+impl Accept for UnixListener {
+    type Conn = UnixStream;
+    type Error = io::Error;
+
+    fn poll_accept(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<Self::Conn>> {
+        UnixListener::poll_accept(self.get_mut(), cx).map(|res| {
+            res.and_then(|(stream, remote)| Ok(UnixStream::server(stream, remote.try_into()?)))
+        })
+    }
+}

--- a/tests/httpbin.rs
+++ b/tests/httpbin.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use http_body_util::BodyExt as _;
 use hyperdriver::client::{conn::transport::tcp::TcpTransportConfig, Client};
 
@@ -15,6 +17,7 @@ async fn httpbin_request(
         .with_tcp(config)
         .with_auto_http()
         .with_default_tls()
+        .with_timeout(Duration::from_secs(5))
         .build();
 
     let res = client.request(req).await?;


### PR DESCRIPTION
By default, Tokio returns the remote address along side the stream during the accept call, and then _may_ return an error from ::peer_addr(). This provides a stream wrapper for TcpStream which stores the remote address in the stream.
