### PR TITLE
UnixAddr bugfix for UnixStream

### DIFF
--- a/justfile
+++ b/justfile
@@ -66,8 +66,9 @@ msrv:
 alias t := test
 # Run cargo tests
 test:
-    cargo +{{rust}} test --features axum,sni,tls,tls-ring,mocks --no-run
-    cargo +{{rust}} test --features axum,sni,tls,tls-ring,mocks
+    cargo +{{rust}} nextest run --features axum,sni,tls,tls-ring,mocks --no-run
+    cargo +{{rust}} nextest run --features axum,sni,tls,tls-ring,mocks
+    cargo +{{rust}} test --features axum,sni,tls,tls-ring,mocks --doc
 
 # Run coverage tests
 coverage:


### PR DESCRIPTION
- **Ensure that unix streams are always opened with remote addr**
- **Move address features to crate::stream**
- **Switch to nextest for local testing**
