### PR TITLE
[server] Remove unnecessary re-borrow for connection future

### DIFF
--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -2,10 +2,13 @@
 
 use std::convert::Infallible;
 use std::fmt;
+#[cfg(feature = "stream")]
 use std::io;
 use std::str::FromStr;
 
+#[cfg(feature = "stream")]
 use camino::Utf8Path;
+#[cfg(feature = "stream")]
 use camino::Utf8PathBuf;
 
 #[cfg(feature = "tls")]
@@ -16,6 +19,7 @@ pub use self::tls::HasTlsConnectionInfo;
 pub use self::tls::TlsConnectionInfo;
 #[doc(hidden)]
 pub use crate::stream::duplex::DuplexAddr;
+#[cfg(feature = "stream")]
 use crate::stream::tcp::make_canonical;
 #[doc(hidden)]
 pub use crate::stream::unix::UnixAddr;
@@ -347,6 +351,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "stream")]
     fn test_make_canonical() {
         assert_eq!(
             make_canonical("[::1]:8080".parse().unwrap()),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -520,7 +520,7 @@ where
                             let mut conn = pin!(conn);
                             loop {
                                 tokio::select! {
-                                    rv = &mut conn.as_mut() => {
+                                    rv = conn.as_mut() => {
                                         if let Err(error) = rv {
                                             debug!("connection error: {}", error.into());
                                         } else {


### PR DESCRIPTION
In the graceful shutdown implementation, the connection future was
unnecessarily re-borrowed as `&mut conn.as_mut()`, which can be
simplified to `conn.as_mut()`, since the receiver of the future is
expecting a `Pin<&mut ...>` type.

Nits: Fixes missing #cfg directives for imports in `src/info/mod.rs`
