### PR TITLE
Delayed drop for Client Connection Pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,6 +702,7 @@ dependencies = [
  "hyper",
  "libc",
  "ouroboros",
+ "parking_lot",
  "pem-rfc7468",
  "pin-project",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ humantime-serde = { version = "1.1.1", optional = true }
 hyper = { version = "1", features = ["full"] }
 libc = { version = "0.2", optional = true }
 ouroboros = { version = "0.18", optional = true }
+parking_lot = { version = "0.12", optional = true, features = ["arc_lock"] }
 pin-project = { version = "1" }
 rustls-native-certs = { version = "0.7.1", optional = true }
 serde = { version = "1", optional = true }
@@ -81,6 +82,7 @@ webpki-roots.version = "0.26"
 axum = ["dep:axum"]
 client = [
     "incoming",
+    "dep:parking_lot",
     "dep:socket2",
     "dep:thiserror",
     "dep:tower-http",

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! 1. The high-level [`Client`] API, which is the most user-friendly and abstracts away most of the details.
 //!    It is "batteries-included", and supports features like redirects, retries and timeouts.
-//! 2. The [`Service`][ClientService] API, which is a lower-level API that allows for more control over the request and response.
+//! 2. The [`Service`][ConnectionPoolService] API, which is a lower-level API that allows for more control over the request and response.
 //!    It presents a `tower::Service` that can be used to send requests and receive responses, and can be wrapped
 //!    by middleware compatible with the tower ecosystem.
 //! 3. The [connection][self::conn] API, which is the lowest-level API that allows for direct control over the
@@ -21,14 +21,14 @@ use tower::ServiceExt;
 
 use self::conn::protocol::auto;
 use self::conn::transport::tcp::TcpTransportConfig;
-pub use self::service::ClientService;
+pub use self::pool::service::ConnectionPoolLayer;
+pub use self::pool::service::ConnectionPoolService;
 use crate::service::SharedService;
 
 mod builder;
 pub mod conn;
 mod error;
 pub mod pool;
-mod service;
 
 pub use self::error::Error;
 pub use self::pool::Config as PoolConfig;
@@ -82,7 +82,7 @@ impl ClientRef {
 
 /// A high-level async HTTP client.
 ///
-/// This client is built on top of the [`Service`][ClientService] API and provides a more user-friendly interface,
+/// This client is built on top of the [`Service`][ConnectionPoolService] API and provides a more user-friendly interface,
 /// including support for retries, redirects and timeouts.
 ///
 /// # Example

--- a/src/client/pool/checkout.rs
+++ b/src/client/pool/checkout.rs
@@ -212,6 +212,7 @@ impl<C: PoolableConnection, T: PoolableTransport, E: 'static> Checkout<C, T, E> 
         waiter: Receiver<Pooled<C>>,
         connect: Option<Connector<C, T, E>>,
         connection: Option<C>,
+        continue_after_premeption: bool,
     ) -> Self {
         #[cfg(debug_assertions)]
         let id = CheckoutId::new();
@@ -237,7 +238,7 @@ impl<C: PoolableConnection, T: PoolableTransport, E: 'static> Checkout<C, T, E> 
                 inner: InnerCheckoutConnecting::Connecting(connector),
                 connection,
                 connection_error: PhantomData,
-                delayed_drop: true,
+                delayed_drop: continue_after_premeption,
                 #[cfg(debug_assertions)]
                 id,
             }
@@ -249,7 +250,7 @@ impl<C: PoolableConnection, T: PoolableTransport, E: 'static> Checkout<C, T, E> 
                 inner: InnerCheckoutConnecting::Waiting,
                 connection,
                 connection_error: PhantomData,
-                delayed_drop: true,
+                delayed_drop: false,
                 #[cfg(debug_assertions)]
                 id,
             }

--- a/src/client/pool/mod.rs
+++ b/src/client/pool/mod.rs
@@ -30,6 +30,7 @@ use tracing::trace;
 mod checkout;
 mod idle;
 pub(super) mod key;
+pub(super) mod service;
 mod weakopt;
 
 pub(crate) use self::checkout::Checkout;
@@ -273,6 +274,10 @@ pub trait PoolableConnection: Unpin + Send + Sized + 'static {
     fn reuse(&mut self) -> Option<Self>;
 }
 
+/// Wrapper type for a connection which is managed by a pool.
+///
+/// This type is used outside of the Pool to ensure that dropped
+/// connections are returned to the pool.
 pub(crate) struct Pooled<C: PoolableConnection> {
     connection: Option<C>,
     is_reused: bool,

--- a/src/client/pool/mod.rs
+++ b/src/client/pool/mod.rs
@@ -103,7 +103,14 @@ impl<C: PoolableConnection> Pool<C> {
         if let Some(connection) = inner.pop(&key) {
             trace!("connection found in pool");
             connector = None;
-            return Checkout::new(key, self, rx, connector, Some(connection));
+            return Checkout::new(
+                key,
+                self,
+                rx,
+                connector,
+                Some(connection),
+                inner.config.continue_after_premeption,
+            );
         }
 
         trace!("checkout interested in pooled connections");
@@ -112,7 +119,7 @@ impl<C: PoolableConnection> Pool<C> {
         if inner.connecting.contains(&key) {
             trace!("connection in progress elsewhere, will wait");
             connector = None;
-            Checkout::new(key, self, rx, connector, None)
+            Checkout::new(key, self, rx, connector, None, false)
         } else {
             if multiplex {
                 // Only block new connection attempts if we can multiplex on this one.
@@ -120,7 +127,14 @@ impl<C: PoolableConnection> Pool<C> {
                 inner.connecting.insert(key.clone());
             }
             trace!("connecting to host");
-            Checkout::new(key, self, rx, connector, None)
+            Checkout::new(
+                key,
+                self,
+                rx,
+                connector,
+                None,
+                inner.config.continue_after_premeption,
+            )
         }
     }
 }
@@ -302,6 +316,9 @@ pub struct Config {
 
     /// The maximum number of idle connections per host.
     pub max_idle_per_host: usize,
+
+    /// Should in-progress connections continue after they get pre-empted by a new connection?
+    pub continue_after_premeption: bool,
 }
 
 impl Default for Config {
@@ -309,6 +326,7 @@ impl Default for Config {
         Self {
             idle_timeout: Some(Duration::from_secs(90)),
             max_idle_per_host: 32,
+            continue_after_premeption: true,
         }
     }
 }
@@ -435,6 +453,7 @@ mod tests {
         let pool = Pool::new(Config {
             idle_timeout: Some(Duration::from_secs(10)),
             max_idle_per_host: 5,
+            continue_after_premeption: false,
         });
 
         let key: key::Key = (
@@ -490,6 +509,7 @@ mod tests {
         let pool = Pool::new(Config {
             idle_timeout: Some(Duration::from_secs(10)),
             max_idle_per_host: 5,
+            continue_after_premeption: false,
         });
 
         let key: key::Key = (
@@ -544,6 +564,7 @@ mod tests {
         let pool = Pool::new(Config {
             idle_timeout: Some(Duration::from_secs(10)),
             max_idle_per_host: 5,
+            continue_after_premeption: false,
         });
 
         let key: key::Key = (
@@ -590,6 +611,7 @@ mod tests {
         let pool = Pool::new(Config {
             idle_timeout: Some(Duration::from_secs(10)),
             max_idle_per_host: 5,
+            continue_after_premeption: false,
         });
 
         let key: key::Key = (
@@ -626,6 +648,7 @@ mod tests {
         let pool = Pool::new(Config {
             idle_timeout: Some(Duration::from_secs(10)),
             max_idle_per_host: 5,
+            continue_after_premeption: false,
         });
 
         let key: key::Key = (
@@ -679,6 +702,7 @@ mod tests {
         let pool = Pool::new(Config {
             idle_timeout: Some(Duration::from_secs(10)),
             max_idle_per_host: 5,
+            continue_after_premeption: false,
         });
 
         let key: key::Key = (
@@ -712,6 +736,7 @@ mod tests {
         let pool = Pool::new(Config {
             idle_timeout: Some(Duration::from_secs(10)),
             max_idle_per_host: 5,
+            continue_after_premeption: false,
         });
 
         let key: key::Key = (
@@ -738,6 +763,7 @@ mod tests {
         let pool = Pool::new(Config {
             idle_timeout: Some(Duration::from_secs(10)),
             max_idle_per_host: 5,
+            continue_after_premeption: false,
         });
 
         let key: key::Key = (
@@ -764,6 +790,7 @@ mod tests {
         let pool = Pool::new(Config {
             idle_timeout: Some(Duration::from_secs(10)),
             max_idle_per_host: 5,
+            continue_after_premeption: false,
         });
         let other = pool.clone();
 

--- a/src/client/pool/mod.rs
+++ b/src/client/pool/mod.rs
@@ -21,9 +21,11 @@ use std::fmt;
 use std::ops::Deref;
 use std::ops::DerefMut;
 use std::sync::Arc;
-use std::sync::Mutex;
+
 use std::time::Duration;
 
+use parking_lot::ArcMutexGuard;
+use parking_lot::Mutex;
 use tokio::sync::oneshot::Sender;
 use tracing::trace;
 
@@ -69,6 +71,12 @@ impl<T: PoolableConnection> Pool<T> {
             inner: Arc::new(Mutex::new(PoolInner::new(config))),
         }
     }
+
+    fn as_ref(&self) -> PoolRef<T> {
+        PoolRef {
+            inner: WeakOpt::downgrade(&self.inner),
+        }
+    }
 }
 
 impl<T: PoolableConnection> Default for Pool<T> {
@@ -88,14 +96,14 @@ impl<C: PoolableConnection> Pool<C> {
     where
         T: PoolableTransport,
     {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.lock();
         let (tx, rx) = tokio::sync::oneshot::channel();
         let mut connector: Option<Connector<C, T, E>> = Some(connector);
 
         if let Some(connection) = inner.pop(&key) {
             trace!("connection found in pool");
             connector = None;
-            return Checkout::new(key, &self.inner, rx, connector, Some(connection));
+            return Checkout::new(key, self, rx, connector, Some(connection));
         }
 
         trace!("checkout interested in pooled connections");
@@ -104,7 +112,7 @@ impl<C: PoolableConnection> Pool<C> {
         if inner.connecting.contains(&key) {
             trace!("connection in progress elsewhere, will wait");
             connector = None;
-            Checkout::new(key, &self.inner, rx, connector, None)
+            Checkout::new(key, self, rx, connector, None)
         } else {
             if multiplex {
                 // Only block new connection attempts if we can multiplex on this one.
@@ -112,8 +120,81 @@ impl<C: PoolableConnection> Pool<C> {
                 inner.connecting.insert(key.clone());
             }
             trace!("connecting to host");
-            Checkout::new(key, &self.inner, rx, connector, None)
+            Checkout::new(key, self, rx, connector, None)
         }
+    }
+}
+
+struct PoolRef<C>
+where
+    C: PoolableConnection,
+{
+    inner: WeakOpt<Mutex<PoolInner<C>>>,
+}
+
+impl<C> fmt::Debug for PoolRef<C>
+where
+    C: PoolableConnection,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("PoolRef").field(&self.inner).finish()
+    }
+}
+
+impl<C> PoolRef<C>
+where
+    C: PoolableConnection,
+{
+    fn none() -> Self {
+        Self {
+            inner: WeakOpt::none(),
+        }
+    }
+
+    #[allow(dead_code)]
+    fn try_lock(&self) -> Option<PoolGuard<C>> {
+        self.inner
+            .upgrade()
+            .and_then(|inner| inner.try_lock_arc().map(PoolGuard))
+    }
+
+    fn lock(&self) -> Option<PoolGuard<C>> {
+        self.inner
+            .upgrade()
+            .map(|inner| PoolGuard(inner.lock_arc()))
+    }
+}
+
+impl<C> Clone for PoolRef<C>
+where
+    C: PoolableConnection,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+struct PoolGuard<C: PoolableConnection>(ArcMutexGuard<parking_lot::RawMutex, PoolInner<C>>);
+
+impl<C> Deref for PoolGuard<C>
+where
+    C: PoolableConnection,
+{
+    type Target = PoolInner<C>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<C> DerefMut for PoolGuard<C>
+where
+    C: PoolableConnection,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 
@@ -154,7 +235,7 @@ impl<C: PoolableConnection> PoolInner<C> {
 }
 
 impl<C: PoolableConnection> PoolInner<C> {
-    fn push(&mut self, key: key::Key, mut connection: C, pool_ref: WeakOpt<Mutex<Self>>) {
+    fn push(&mut self, key: key::Key, mut connection: C, pool_ref: PoolRef<C>) {
         self.connecting.remove(&key);
 
         if let Some(waiters) = self.waiting.get_mut(&key) {
@@ -282,7 +363,7 @@ pub(crate) struct Pooled<C: PoolableConnection> {
     connection: Option<C>,
     is_reused: bool,
     key: key::Key,
-    pool: weakopt::WeakOpt<Mutex<PoolInner<C>>>,
+    pool: PoolRef<C>,
 }
 
 impl<C: fmt::Debug + PoolableConnection> fmt::Debug for Pooled<C> {
@@ -313,11 +394,9 @@ impl<C: PoolableConnection> Drop for Pooled<C> {
     fn drop(&mut self) {
         if let Some(connection) = self.connection.take() {
             if connection.is_open() && !self.is_reused {
-                if let Some(pool) = self.pool.upgrade() {
-                    if let Ok(mut inner) = pool.lock() {
-                        trace!(key=%self.key, "open connection returned to pool");
-                        inner.push(self.key.clone(), connection, self.pool.clone());
-                    }
+                if let Some(mut pool) = self.pool.lock() {
+                    trace!(key=%self.key, "open connection returned to pool");
+                    pool.push(self.key.clone(), connection, self.pool.clone());
                 }
             }
         }
@@ -342,9 +421,9 @@ mod tests {
         let config = Config::default();
         let pool: Pool<MockStream> = Pool::new(config);
 
-        assert!(pool.inner.lock().unwrap().config.idle_timeout.unwrap() > Duration::from_secs(1));
-        assert!(pool.inner.lock().unwrap().config.max_idle_per_host > 0);
-        assert!(pool.inner.lock().unwrap().config.max_idle_per_host < 2048);
+        assert!(pool.inner.lock().config.idle_timeout.unwrap() > Duration::from_secs(1));
+        assert!(pool.inner.lock().config.max_idle_per_host > 0);
+        assert!(pool.inner.lock().config.max_idle_per_host < 2048);
     }
 
     assert_impl_all!(Pool<MockStream>: Clone);
@@ -531,9 +610,8 @@ mod tests {
 
         // Return the connection to the pool, sending it out to the new checkout
         // that is waiting, cancelling the checkout connect.
-        let pool_ref = WeakOpt::downgrade(&pool.inner);
 
-        pool.inner.lock().unwrap().push(key.clone(), conn, pool_ref);
+        pool.inner.lock().push(key.clone(), conn, pool.as_ref());
 
         let conn = checkout.now_or_never().unwrap().unwrap();
 
@@ -574,7 +652,6 @@ mod tests {
         assert!(!pool
             .inner
             .lock()
-            .unwrap()
             .waiting
             .get(&key)
             .expect("no waiting connections in pool")
@@ -587,11 +664,9 @@ mod tests {
         tracing::debug!("Inserting original connection");
         // Return the connection to the pool, sending it out to the new checkout
         // that is waiting, cancelling the checkout connect.
-        let pool_ref = WeakOpt::downgrade(&pool.inner);
         pool.inner
             .lock()
-            .unwrap()
-            .push(key.clone(), conn_first, pool_ref);
+            .push(key.clone(), conn_first, pool.as_ref());
 
         assert!(conn.is_open());
         assert_ne!(conn.id(), first_id, "connection should not be re-used");

--- a/src/client/pool/service.rs
+++ b/src/client/pool/service.rs
@@ -1,0 +1,455 @@
+use std::fmt;
+use std::future::poll_fn;
+use std::future::Future;
+use std::task::Poll;
+
+use futures_util::FutureExt;
+use http_body::Body;
+use pin_project::pin_project;
+use tower::util::Oneshot;
+use tower::ServiceExt;
+
+use crate::client::conn::connection::ConnectionError;
+use crate::client::conn::connection::HttpConnection;
+use crate::client::conn::protocol::auto::HttpConnectionBuilder;
+use crate::client::conn::protocol::HttpProtocol;
+use crate::client::conn::transport::tcp::TcpTransport;
+use crate::client::conn::transport::TransportStream;
+use crate::client::conn::Connection;
+use crate::client::conn::Protocol;
+use crate::client::conn::TlsTransport;
+use crate::client::conn::Transport;
+use crate::client::pool;
+use crate::client::pool::Checkout;
+use crate::client::pool::Connector;
+use crate::client::pool::PoolableConnection;
+use crate::client::Error;
+use crate::info::HasConnectionInfo;
+use crate::service::client::ExecuteRequest;
+
+/// Layer which adds connection pooling and converts
+/// to an inner service which accepts `ExecuteRequest`
+/// from an outer service which accepts `http::Request`.
+pub struct ConnectionPoolLayer<T, P, BIn> {
+    transport: T,
+    protocol: P,
+    pool: Option<pool::Config>,
+    _body: std::marker::PhantomData<fn(BIn) -> ()>,
+}
+
+impl<T: fmt::Debug, P: fmt::Debug, BIn> fmt::Debug for ConnectionPoolLayer<T, P, BIn> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ConnectionPoolLayer")
+            .field("transport", &self.transport)
+            .field("protocol", &self.protocol)
+            .field("pool", &self.pool)
+            .finish()
+    }
+}
+
+impl<T, P, BIn> ConnectionPoolLayer<T, P, BIn> {
+    /// Layer for connection pooling.
+    pub fn new(transport: T, protocol: P) -> Self {
+        Self {
+            transport,
+            protocol,
+            pool: None,
+            _body: std::marker::PhantomData,
+        }
+    }
+
+    /// Set the connection pool configuration.
+    pub fn with_pool(mut self, pool: pool::Config) -> Self {
+        self.pool = Some(pool);
+        self
+    }
+
+    /// Set the connection pool configuration to an optional value.
+    pub fn with_optional_pool(mut self, pool: Option<pool::Config>) -> Self {
+        self.pool = pool;
+        self
+    }
+
+    /// Disable connection pooling.
+    pub fn without_pool(mut self) -> Self {
+        self.pool = None;
+        self
+    }
+}
+
+impl<T, P, BIn> Clone for ConnectionPoolLayer<T, P, BIn>
+where
+    T: Clone,
+    P: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            transport: self.transport.clone(),
+            protocol: self.protocol.clone(),
+            pool: self.pool.clone(),
+            _body: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T, P, S, BIn> tower::layer::Layer<S> for ConnectionPoolLayer<T, P, BIn>
+where
+    T: Transport + Clone + Send + Sync + 'static,
+    P: Protocol<T::IO, BIn> + Clone + Send + Sync + 'static,
+    P::Connection: PoolableConnection,
+{
+    type Service = ConnectionPoolService<T, P, S, BIn>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        let pool = self.pool.clone().map(pool::Pool::new);
+
+        ConnectionPoolService {
+            transport: self.transport.clone(),
+            protocol: self.protocol.clone(),
+            service,
+            pool,
+            _body: std::marker::PhantomData,
+        }
+    }
+}
+
+/// A service which gets a connection from a possible connection pool and passes it to
+/// an inner service to execute that request.
+///
+/// This service will accept [`http::Request`] objects, but expects the inner service
+/// to accept [`ExecuteRequest`] objects, which bundle the connection with the request.
+///
+/// The simplest interior service is [`crate::service::RequestExecutor`], which will execute the request
+/// on the connection and return the response.
+#[derive(Debug)]
+pub struct ConnectionPoolService<T, P, S, BIn = crate::Body>
+where
+    T: Transport,
+    P: Protocol<T::IO, BIn>,
+    P::Connection: PoolableConnection,
+{
+    pub(super) transport: T,
+    pub(super) protocol: P,
+    pub(super) service: S,
+    pub(super) pool: Option<pool::Pool<P::Connection>>,
+    pub(super) _body: std::marker::PhantomData<fn(BIn) -> ()>,
+}
+
+impl<T, P, S, BIn> ConnectionPoolService<T, P, S, BIn>
+where
+    T: Transport,
+    P: Protocol<T::IO, BIn>,
+    P::Connection: PoolableConnection,
+{
+    /// Create a new client with the given transport, protocol, and pool configuration.
+    pub fn new(transport: T, protocol: P, service: S, pool: pool::Config) -> Self {
+        Self {
+            transport,
+            protocol,
+            service,
+            pool: Some(pool::Pool::new(pool)),
+            _body: std::marker::PhantomData,
+        }
+    }
+
+    /// Disable connection pooling for this client.
+    pub fn without_pool(self) -> Self {
+        Self { pool: None, ..self }
+    }
+}
+
+impl
+    ConnectionPoolService<
+        TlsTransport<TcpTransport>,
+        HttpConnectionBuilder<crate::Body>,
+        crate::service::client::RequestExecutor<HttpConnection<crate::Body>, crate::Body>,
+        crate::Body,
+    >
+{
+    /// Create a new client with the default configuration for making requests over TCP
+    /// connections using the HTTP protocol.
+    ///
+    /// When the `tls` feature is enabled, this will also add support for `tls` when
+    /// using the `https` scheme, with a default TLS configuration that will rely
+    /// on the system's certificate store.
+    pub fn new_tcp_http() -> Self {
+        Self {
+            pool: Some(pool::Pool::new(pool::Config {
+                idle_timeout: Some(std::time::Duration::from_secs(90)),
+                max_idle_per_host: 32,
+            })),
+
+            transport: Default::default(),
+
+            protocol: HttpConnectionBuilder::default(),
+
+            service: crate::service::client::RequestExecutor::new(),
+
+            _body: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<P, T, S, BIn> Clone for ConnectionPoolService<T, P, S, BIn>
+where
+    P: Protocol<T::IO, BIn> + Clone,
+    P::Connection: PoolableConnection,
+    T: Transport + Clone,
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            protocol: self.protocol.clone(),
+            transport: self.transport.clone(),
+            pool: self.pool.clone(),
+            service: self.service.clone(),
+            _body: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<P, C, T, S, BIn> ConnectionPoolService<T, P, S, BIn>
+where
+    C: Connection<BIn> + PoolableConnection,
+    P: Protocol<T::IO, BIn, Connection = C, Error = ConnectionError>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    T: Transport + 'static,
+    T::IO: Unpin,
+    <<T as Transport>::IO as HasConnectionInfo>::Addr: Send,
+{
+    #[allow(clippy::type_complexity)]
+    fn connect_to(
+        &self,
+        uri: http::Uri,
+        http_protocol: HttpProtocol,
+    ) -> Result<Checkout<P::Connection, TransportStream<T::IO>, ConnectionError>, ConnectionError>
+    {
+        let key: pool::Key = uri.clone().try_into()?;
+        let mut protocol = self.protocol.clone();
+        let mut transport = self.transport.clone();
+
+        let connector = Connector::new(
+            move || async move {
+                poll_fn(|cx| Transport::poll_ready(&mut transport, cx))
+                    .await
+                    .map_err(|error| ConnectionError::Connecting(error.into()))?;
+                transport
+                    .connect(uri)
+                    .await
+                    .map_err(|error| ConnectionError::Connecting(error.into()))
+            },
+            Box::new(move |transport| {
+                Box::pin(async move {
+                    poll_fn(|cx| Protocol::poll_ready(&mut protocol, cx))
+                        .await
+                        .map_err(|error| ConnectionError::Handshake(error.into()))?;
+                    protocol
+                        .connect(transport, http_protocol)
+                        .await
+                        .map_err(|error| ConnectionError::Handshake(error.into()))
+                }) as _
+            }),
+        );
+
+        if let Some(pool) = self.pool.as_ref() {
+            Ok(pool.checkout(key, http_protocol.multiplex(), connector))
+        } else {
+            Ok(Checkout::detached(key, connector))
+        }
+    }
+}
+
+impl<P, C, T, S, BIn, BOut> tower::Service<http::Request<BIn>>
+    for ConnectionPoolService<T, P, S, BIn>
+where
+    C: Connection<BIn, ResBody = BOut> + PoolableConnection,
+    P: Protocol<T::IO, BIn, Connection = C, Error = ConnectionError>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    T: Transport + 'static,
+    T::IO: Unpin,
+    <<T as Transport>::IO as HasConnectionInfo>::Addr: Send,
+    S: tower::Service<ExecuteRequest<C, BIn>, Response = http::Response<BOut>> + Clone,
+    S::Error: Into<Error>,
+    BOut: Body + Unpin + 'static,
+    BIn: Body + Unpin + Send + 'static,
+    <BIn as Body>::Data: Send,
+    <BIn as Body>::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+{
+    type Response = http::Response<BOut>;
+    type Error = Error;
+    type Future = ResponseFuture<P::Connection, TransportStream<T::IO>, S, BIn, BOut>;
+
+    fn poll_ready(&mut self, _: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: http::Request<BIn>) -> Self::Future {
+        let uri = request.uri().clone();
+
+        let protocol: HttpProtocol = request.version().into();
+
+        match self.connect_to(uri, protocol) {
+            Ok(checkout) => ResponseFuture::new(checkout, request, self.service.clone()),
+            Err(error) => ResponseFuture::error(error),
+        }
+    }
+}
+
+impl<P, C, T, S, BIn, BOut> ConnectionPoolService<T, P, S, BIn>
+where
+    C: Connection<BIn, ResBody = BOut> + PoolableConnection,
+    P: Protocol<T::IO, BIn, Connection = C, Error = ConnectionError>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    T: Transport + 'static,
+    T::IO: Unpin,
+    S: tower::Service<ExecuteRequest<C, BIn>, Response = http::Response<BOut>> + Clone,
+    S::Error: Into<Error>,
+    BIn: Body + Unpin + Send + 'static,
+    <BIn as Body>::Data: Send,
+    <BIn as Body>::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    BOut: Body + Unpin + 'static,
+    <<T as Transport>::IO as HasConnectionInfo>::Addr: Send,
+{
+    /// Send an http Request, and return a Future of the Response.
+    pub fn request(&self, request: http::Request<BIn>) -> Oneshot<Self, http::Request<BIn>> {
+        self.clone().oneshot(request)
+    }
+}
+
+/// A future that resolves to an HTTP response.
+#[pin_project]
+pub struct ResponseFuture<C, T, S, BIn, BOut>
+where
+    C: Connection<BIn> + pool::PoolableConnection,
+    T: pool::PoolableTransport,
+    S: tower::Service<ExecuteRequest<C, BIn>, Response = http::Response<BOut>>,
+{
+    #[pin]
+    inner: ResponseFutureState<C, T, S, BIn, BOut>,
+    _body: std::marker::PhantomData<fn(BIn) -> BOut>,
+}
+
+impl<C, T, S, BIn, BOut> fmt::Debug for ResponseFuture<C, T, S, BIn, BOut>
+where
+    C: Connection<BIn> + pool::PoolableConnection,
+    T: pool::PoolableTransport,
+    S: tower::Service<ExecuteRequest<C, BIn>, Response = http::Response<BOut>>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ResponseFuture").finish()
+    }
+}
+
+impl<C, T, S, BIn, BOut> ResponseFuture<C, T, S, BIn, BOut>
+where
+    C: Connection<BIn> + pool::PoolableConnection,
+    T: pool::PoolableTransport,
+    S: tower::Service<ExecuteRequest<C, BIn>, Response = http::Response<BOut>>,
+{
+    fn new(
+        checkout: Checkout<C, T, ConnectionError>,
+        request: http::Request<BIn>,
+        service: S,
+    ) -> Self {
+        Self {
+            inner: ResponseFutureState::Checkout {
+                checkout,
+                request: Some(request),
+                service,
+            },
+            _body: std::marker::PhantomData,
+        }
+    }
+
+    fn error(error: ConnectionError) -> Self {
+        Self {
+            inner: ResponseFutureState::ConnectionError(Some(error)),
+            _body: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<C, T, S, BIn, BOut> Future for ResponseFuture<C, T, S, BIn, BOut>
+where
+    C: Connection<BIn, ResBody = BOut> + pool::PoolableConnection,
+    T: pool::PoolableTransport,
+    S: tower::Service<ExecuteRequest<C, BIn>, Response = http::Response<BOut>>,
+    S::Error: Into<crate::client::Error>,
+    BOut: Body + Unpin + 'static,
+    BIn: Body + Unpin + Send + 'static,
+    <BIn as Body>::Data: Send,
+    <BIn as Body>::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+{
+    type Output = Result<http::Response<BOut>, Error>;
+
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Self::Output> {
+        loop {
+            let mut this = self.as_mut().project();
+            let next = match this.inner.as_mut().project() {
+                ResponseFutureStateProj::Checkout {
+                    checkout,
+                    request,
+                    service,
+                } => match checkout.poll_unpin(cx) {
+                    Poll::Ready(Ok(conn)) => {
+                        ResponseFutureState::Request(service.call(ExecuteRequest {
+                            conn,
+                            request: request.take().expect("request polled again"),
+                        }))
+                    }
+                    Poll::Ready(Err(error)) => {
+                        return Poll::Ready(Err(error.into()));
+                    }
+                    Poll::Pending => {
+                        return Poll::Pending;
+                    }
+                },
+                ResponseFutureStateProj::Request(fut) => match fut.poll(cx) {
+                    Poll::Ready(Ok(response)) => {
+                        return Poll::Ready(Ok(response));
+                    }
+                    Poll::Ready(Err(error)) => {
+                        return Poll::Ready(Err(error.into()));
+                    }
+                    Poll::Pending => {
+                        return Poll::Pending;
+                    }
+                },
+                ResponseFutureStateProj::ConnectionError(error) => {
+                    return Poll::Ready(Err(Error::Connection(
+                        error.take().expect("error polled again").into(),
+                    )));
+                }
+            };
+            this.inner.set(next);
+        }
+    }
+}
+
+#[pin_project(project=ResponseFutureStateProj)]
+enum ResponseFutureState<C, T, S, BIn, BOut>
+where
+    C: Connection<BIn> + pool::PoolableConnection,
+    T: pool::PoolableTransport,
+    S: tower::Service<ExecuteRequest<C, BIn>, Response = http::Response<BOut>>,
+{
+    Checkout {
+        checkout: Checkout<C, T, ConnectionError>,
+        request: Option<http::Request<BIn>>,
+        service: S,
+    },
+    ConnectionError(Option<ConnectionError>),
+    Request(#[pin] S::Future),
+}

--- a/src/client/pool/service.rs
+++ b/src/client/pool/service.rs
@@ -177,6 +177,7 @@ impl
             pool: Some(pool::Pool::new(pool::Config {
                 idle_timeout: Some(std::time::Duration::from_secs(90)),
                 max_idle_per_host: 32,
+                continue_after_premeption: true,
             })),
 
             transport: Default::default(),

--- a/src/service/error.rs
+++ b/src/service/error.rs
@@ -1,0 +1,163 @@
+//! Helpers for middleware that might error.
+
+use std::fmt;
+
+pub use self::future::MaybeErrorFuture;
+
+/// A middleware that calls some (non-async) function before
+/// calling the inner service, and skips the inner service if the function
+/// returns an error.
+#[derive(Clone)]
+pub struct PreprocessService<S, F> {
+    inner: S,
+    preprocessor: F,
+}
+
+impl<S: fmt::Debug, F> fmt::Debug for PreprocessService<S, F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PreprocessService")
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+impl<S, F> PreprocessService<S, F> {
+    /// Helper Service for middleware that might error.
+    pub fn new(inner: S, preprocessor: F) -> Self {
+        Self {
+            inner,
+            preprocessor,
+        }
+    }
+
+    /// Get a reference to the inner service.
+    pub fn service(&self) -> &S {
+        &self.inner
+    }
+}
+
+impl<S, F, R> tower::Service<R> for PreprocessService<S, F>
+where
+    S: tower::Service<R>,
+    F: Fn(R) -> Result<R, S::Error>,
+{
+    type Response = S::Response;
+
+    type Error = S::Error;
+
+    type Future = MaybeErrorFuture<S::Future, S::Response, S::Error>;
+
+    #[inline]
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    #[inline]
+    fn call(&mut self, req: R) -> Self::Future {
+        match (self.preprocessor)(req) {
+            Ok(req) => MaybeErrorFuture::future(self.inner.call(req)),
+            Err(error) => MaybeErrorFuture::error(error),
+        }
+    }
+}
+
+/// A layer that wraps a service with a preprocessor function.
+#[derive(Clone)]
+pub struct PreprocessLayer<F> {
+    preprocessor: F,
+}
+
+impl<F> PreprocessLayer<F> {
+    /// Create a new `PreprocessLayer` wrapping the given preprocessor function.
+    pub fn new(preprocessor: F) -> Self {
+        Self { preprocessor }
+    }
+}
+
+impl<F> fmt::Debug for PreprocessLayer<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PreprocessLayer").finish()
+    }
+}
+
+impl<S, F: Clone> tower::layer::Layer<S> for PreprocessLayer<F> {
+    type Service = PreprocessService<S, F>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        PreprocessService::new(inner, self.preprocessor.clone())
+    }
+}
+
+mod future {
+
+    use std::{fmt, future::Future, marker::PhantomData, task::Poll};
+
+    use pin_project::pin_project;
+
+    #[pin_project(project = MaybeErrorFutureStateProj)]
+    enum MaybeErrorFutureState<F, E> {
+        Inner(#[pin] F),
+        Error(Option<E>),
+    }
+
+    impl<F, E: fmt::Debug> fmt::Debug for MaybeErrorFutureState<F, E> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                Self::Inner(_) => f.debug_tuple("Inner").finish(),
+                Self::Error(error) => f.debug_tuple("Error").field(error).finish(),
+            }
+        }
+    }
+
+    /// Future for when a service either errors before yielding,
+    /// or continues. This is us
+    #[derive(Debug)]
+    #[pin_project]
+    pub struct MaybeErrorFuture<F, R, E> {
+        #[pin]
+        state: MaybeErrorFutureState<F, E>,
+        response: PhantomData<fn() -> R>,
+    }
+
+    impl<F, R, E> MaybeErrorFuture<F, R, E> {
+        /// Create a future that resolves to the contained service
+        pub fn future(inner: F) -> Self {
+            Self {
+                state: MaybeErrorFutureState::Inner(inner),
+                response: PhantomData,
+            }
+        }
+
+        /// Create a future that immediately resolves to an error.
+        pub fn error(error: E) -> Self {
+            Self {
+                state: MaybeErrorFutureState::Error(Some(error)),
+                response: PhantomData,
+            }
+        }
+    }
+
+    impl<F, R, E> Future for MaybeErrorFuture<F, R, E>
+    where
+        F: Future<Output = Result<R, E>>,
+    {
+        type Output = Result<R, E>;
+
+        fn poll(
+            self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> Poll<Self::Output> {
+            let mut this = self.project();
+
+            match this.state.as_mut().project() {
+                MaybeErrorFutureStateProj::Inner(inner) => inner.poll(cx),
+                MaybeErrorFutureStateProj::Error(error) => {
+                    Poll::Ready(Err(error.take().expect("polled after error")))
+                }
+            }
+        }
+    }
+}

--- a/src/service/host.rs
+++ b/src/service/host.rs
@@ -1,0 +1,202 @@
+//! Middleware for setting the Host header of a request.
+use http;
+use http::uri::Port;
+use http::HeaderValue;
+use http::Uri;
+
+use crate::client::conn::Connection;
+use crate::client::pool::PoolableConnection;
+
+use super::ExecuteRequest;
+
+/// Returns true if the URI scheme is presumed secure.
+fn is_schema_secure(uri: &Uri) -> bool {
+    uri.scheme_str()
+        .map(|scheme_str| matches!(scheme_str, "wss" | "https"))
+        .unwrap_or_default()
+}
+
+/// Returns the port if it is not the default port for the scheme.
+fn get_non_default_port(uri: &Uri) -> Option<Port<&str>> {
+    match (uri.port().map(|p| p.as_u16()), is_schema_secure(uri)) {
+        (Some(443), true) => None,
+        (Some(80), false) => None,
+        _ => uri.port(),
+    }
+}
+
+/// Set the Host header on the request if it is not already set,
+/// using the authority from the URI.
+fn set_host_header<B>(request: &mut http::Request<B>) {
+    if request.uri().host().is_none() {
+        tracing::debug!(uri=%request.uri(), "request uri has no host");
+        return;
+    }
+
+    let uri = request.uri().clone();
+
+    request
+        .headers_mut()
+        .entry(http::header::HOST)
+        .or_insert_with(|| {
+            let hostname = uri.host().expect("authority implies host");
+            if let Some(port) = get_non_default_port(&uri) {
+                let s = format!("{}:{}", hostname, port);
+                HeaderValue::from_str(&s)
+            } else {
+                HeaderValue::from_str(hostname)
+            }
+            .expect("uri host is valid header value")
+        });
+}
+
+/// Middleware which sets the Host header on requests.
+#[derive(Debug, Default, Clone)]
+pub struct SetHostHeader<S> {
+    inner: S,
+}
+
+impl<S, B> tower::Service<http::Request<B>> for SetHostHeader<S>
+where
+    S: tower::Service<http::Request<B>>,
+{
+    type Response = S::Response;
+
+    type Error = S::Error;
+
+    type Future = S::Future;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: http::Request<B>) -> Self::Future {
+        if req.version() < http::Version::HTTP_2 {
+            set_host_header(&mut req);
+        }
+
+        self.inner.call(req)
+    }
+}
+
+impl<S, B, C> tower::Service<ExecuteRequest<C, B>> for SetHostHeader<S>
+where
+    S: tower::Service<ExecuteRequest<C, B>>,
+    C: Connection<B> + PoolableConnection,
+{
+    type Response = S::Response;
+
+    type Error = S::Error;
+
+    type Future = S::Future;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: ExecuteRequest<C, B>) -> Self::Future {
+        if req.connection().version() < http::Version::HTTP_2 {
+            set_host_header(req.request_mut());
+        }
+
+        self.inner.call(req)
+    }
+}
+
+/// Layer for setting the Host header on requests.
+#[derive(Debug, Default, Clone)]
+pub struct SetHostHeaderLayer {
+    _priv: (),
+}
+
+impl SetHostHeaderLayer {
+    /// Create a new SetHostHeaderLayer.
+    pub fn new() -> Self {
+        Self { _priv: () }
+    }
+}
+
+impl<S> tower::layer::Layer<S> for SetHostHeaderLayer {
+    type Service = SetHostHeader<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        SetHostHeader { inner }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_set_host_header() {
+        let mut request = http::Request::new(());
+        *request.uri_mut() = "http://example.com".parse().unwrap();
+        set_host_header(&mut request);
+        assert_eq!(
+            request.headers().get(http::header::HOST).unwrap(),
+            "example.com"
+        );
+
+        let mut request = http::Request::new(());
+        *request.uri_mut() = "http://example.com:8080".parse().unwrap();
+        set_host_header(&mut request);
+        assert_eq!(
+            request.headers().get(http::header::HOST).unwrap(),
+            "example.com:8080"
+        );
+
+        let mut request = http::Request::new(());
+        *request.uri_mut() = "https://example.com".parse().unwrap();
+        set_host_header(&mut request);
+        assert_eq!(
+            request.headers().get(http::header::HOST).unwrap(),
+            "example.com"
+        );
+
+        let mut request = http::Request::new(());
+        *request.uri_mut() = "https://example.com:8443".parse().unwrap();
+        set_host_header(&mut request);
+        assert_eq!(
+            request.headers().get(http::header::HOST).unwrap(),
+            "example.com:8443"
+        );
+    }
+
+    #[test]
+    fn test_is_schema_secure() {
+        let uri = "http://example.com".parse().unwrap();
+        assert!(!is_schema_secure(&uri));
+
+        let uri = "https://example.com".parse().unwrap();
+        assert!(is_schema_secure(&uri));
+
+        let uri = "ws://example.com".parse().unwrap();
+        assert!(!is_schema_secure(&uri));
+
+        let uri = "wss://example.com".parse().unwrap();
+        assert!(is_schema_secure(&uri));
+    }
+
+    #[test]
+    fn test_get_non_default_port() {
+        let uri = "http://example.com".parse().unwrap();
+        assert_eq!(get_non_default_port(&uri).map(|p| p.as_u16()), None);
+
+        let uri = "http://example.com:8080".parse().unwrap();
+        assert_eq!(get_non_default_port(&uri).map(|p| p.as_u16()), Some(8080));
+
+        let uri = "https://example.com".parse().unwrap();
+        assert_eq!(get_non_default_port(&uri).map(|p| p.as_u16()), None);
+
+        let uri = "https://example.com:8443".parse().unwrap();
+        assert_eq!(get_non_default_port(&uri).map(|p| p.as_u16()), Some(8443));
+    }
+}

--- a/src/service/http.rs
+++ b/src/service/http.rs
@@ -47,6 +47,415 @@ where
     }
 }
 
+#[cfg(feature = "client")]
+pub(super) mod http1 {
+
+    use std::fmt;
+    use std::task::{Context, Poll};
+
+    use ::http;
+    use http::uri::Scheme;
+    use http::Uri;
+
+    use crate::client::conn::Connection;
+    use crate::client::pool::PoolableConnection;
+    use crate::client::Error;
+    use crate::service::client::ExecuteRequest;
+    use crate::service::error::MaybeErrorFuture;
+    use crate::service::error::PreprocessService;
+
+    type PreprocessFn<C, B, E> = fn(ExecuteRequest<C, B>) -> Result<ExecuteRequest<C, B>, E>;
+
+    /// A service that checks if the request is HTTP/1.1 compatible.
+    #[derive(Debug)]
+    pub struct Http1ChecksService<S, C, B>
+    where
+        S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
+        C: Connection<B> + PoolableConnection,
+    {
+        inner: PreprocessService<S, PreprocessFn<C, B, S::Error>>,
+    }
+
+    impl<S, C, B> tower::Service<ExecuteRequest<C, B>> for Http1ChecksService<S, C, B>
+    where
+        S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
+        C: Connection<B> + PoolableConnection,
+    {
+        type Response = S::Response;
+
+        type Error = S::Error;
+
+        type Future = MaybeErrorFuture<S::Future, S::Response, S::Error>;
+
+        fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            self.inner.poll_ready(cx)
+        }
+
+        fn call(&mut self, req: ExecuteRequest<C, B>) -> Self::Future {
+            self.inner.call(req)
+        }
+    }
+
+    impl<S, C, B> Clone for Http1ChecksService<S, C, B>
+    where
+        S: tower::Service<ExecuteRequest<C, B>, Error = Error> + Clone,
+        C: Connection<B> + PoolableConnection,
+    {
+        fn clone(&self) -> Self {
+            Self {
+                inner: self.inner.clone(),
+            }
+        }
+    }
+
+    impl<S, C, B> Http1ChecksService<S, C, B>
+    where
+        S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
+        C: Connection<B> + PoolableConnection,
+    {
+        /// Create a new `Http1ChecksService`.
+        pub fn new(service: S) -> Self {
+            Self {
+                inner: PreprocessService::new(service, check_http1_request),
+            }
+        }
+    }
+
+    /// A layer that checks if the request is HTTP/1.1 compatible.
+    pub struct Http1ChecksLayer<C, B> {
+        processor: std::marker::PhantomData<fn(C, B)>,
+    }
+
+    impl<C, B> Http1ChecksLayer<C, B> {
+        /// Create a new `Http1ChecksLayer`.
+        pub fn new() -> Self {
+            Self {
+                processor: std::marker::PhantomData,
+            }
+        }
+    }
+
+    impl<C, B> Default for Http1ChecksLayer<C, B> {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl<C, B> Clone for Http1ChecksLayer<C, B> {
+        fn clone(&self) -> Self {
+            Self::new()
+        }
+    }
+
+    impl<C, B> fmt::Debug for Http1ChecksLayer<C, B> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("Http1ChecksLayer").finish()
+        }
+    }
+
+    impl<C, B, S> tower::layer::Layer<S> for Http1ChecksLayer<C, B>
+    where
+        S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
+        C: Connection<B> + PoolableConnection,
+    {
+        type Service = Http1ChecksService<S, C, B>;
+
+        fn layer(&self, service: S) -> Self::Service {
+            Http1ChecksService::new(service)
+        }
+    }
+
+    fn check_http1_request<C, B>(
+        mut req: ExecuteRequest<C, B>,
+    ) -> Result<ExecuteRequest<C, B>, Error>
+    where
+        C: Connection<B> + PoolableConnection,
+    {
+        if req.connection().version() >= http::Version::HTTP_2 {
+            return Ok(req);
+        }
+
+        if req.request().method() == http::Method::CONNECT {
+            authority_form(req.request_mut().uri_mut());
+
+            // If the URI is to HTTPS, and the connector claimed to be a proxy,
+            // then it *should* have tunneled, and so we don't want to send
+            // absolute-form in that case.
+            if req.request().uri().scheme() == Some(&Scheme::HTTPS) {
+                origin_form(req.request_mut().uri_mut());
+            }
+        } else if req.request().uri().scheme().is_none()
+            || req.request().uri().authority().is_none()
+        {
+            absolute_form(req.request_mut().uri_mut());
+        } else {
+            origin_form(req.request_mut().uri_mut());
+        }
+
+        Ok(req)
+    }
+
+    /// Convert the URI to authority-form, if it is not already.
+    ///
+    /// This is the form of the URI with just the authority and a default
+    /// path and scheme. This is used in HTTP/1 CONNECT requests.
+    fn authority_form(uri: &mut Uri) {
+        *uri = match uri.authority() {
+            Some(auth) => {
+                let mut parts = ::http::uri::Parts::default();
+                parts.authority = Some(auth.clone());
+                Uri::from_parts(parts).expect("authority is valid")
+            }
+            None => {
+                unreachable!("authority_form with relative uri");
+            }
+        };
+    }
+
+    fn absolute_form(uri: &mut Uri) {
+        debug_assert!(uri.scheme().is_some(), "absolute_form needs a scheme");
+        debug_assert!(
+            uri.authority().is_some(),
+            "absolute_form needs an authority"
+        );
+    }
+
+    /// Convert the URI to origin-form, if it is not already.
+    ///
+    /// This form of the URI has no scheme or authority, and contains just
+    /// the path, usually used in HTTP/1 requests.
+    fn origin_form(uri: &mut Uri) {
+        let path = match uri.path_and_query() {
+            Some(path) if path.as_str() != "/" => {
+                let mut parts = ::http::uri::Parts::default();
+                parts.path_and_query = Some(path.clone());
+                Uri::from_parts(parts).expect("path is valid uri")
+            }
+            _none_or_just_slash => {
+                debug_assert!(Uri::default() == "/");
+                Uri::default()
+            }
+        };
+        *uri = path
+    }
+
+    #[cfg(test)]
+    mod tests {
+
+        use super::*;
+
+        #[test]
+        fn test_origin_form() {
+            let mut uri = "http://example.com".parse().unwrap();
+            origin_form(&mut uri);
+            assert_eq!(uri, "/");
+
+            let mut uri = "/some/path/here".parse().unwrap();
+            origin_form(&mut uri);
+            assert_eq!(uri, "/some/path/here");
+
+            let mut uri = "http://example.com:8080/some/path?query#fragment"
+                .parse()
+                .unwrap();
+            origin_form(&mut uri);
+            assert_eq!(uri, "/some/path?query");
+
+            let mut uri = "/".parse().unwrap();
+            origin_form(&mut uri);
+            assert_eq!(uri, "/");
+        }
+
+        #[test]
+        fn test_absolute_form() {
+            let mut uri = "http://example.com".parse().unwrap();
+            absolute_form(&mut uri);
+            assert_eq!(uri, "http://example.com");
+
+            let mut uri = "http://example.com:8080".parse().unwrap();
+            absolute_form(&mut uri);
+            assert_eq!(uri, "http://example.com:8080");
+
+            let mut uri = "https://example.com/some/path?query".parse().unwrap();
+            absolute_form(&mut uri);
+            assert_eq!(uri, "https://example.com/some/path?query");
+
+            let mut uri = "https://example.com:8443".parse().unwrap();
+            absolute_form(&mut uri);
+            assert_eq!(uri, "https://example.com:8443");
+
+            let mut uri = "http://example.com:443".parse().unwrap();
+            absolute_form(&mut uri);
+            assert_eq!(uri, "http://example.com:443");
+
+            let mut uri = "https://example.com:80".parse().unwrap();
+            absolute_form(&mut uri);
+            assert_eq!(uri, "https://example.com:80");
+        }
+    }
+}
+
+#[cfg(feature = "client")]
+pub(super) mod http2 {
+    use std::fmt;
+    use std::task::{Context, Poll};
+
+    use ::http;
+
+    use crate::client::conn::Connection;
+    use crate::client::pool::PoolableConnection;
+    use crate::client::Error;
+    use crate::service::client::ExecuteRequest;
+    use crate::service::error::{MaybeErrorFuture, PreprocessService};
+
+    const CONNECTION_HEADERS: [http::HeaderName; 5] = [
+        http::header::CONNECTION,
+        http::HeaderName::from_static("proxy-connection"),
+        http::HeaderName::from_static("keep-alive"),
+        http::header::TRANSFER_ENCODING,
+        http::header::UPGRADE,
+    ];
+
+    type PreprocessFn<C, B, E> = fn(ExecuteRequest<C, B>) -> Result<ExecuteRequest<C, B>, E>;
+
+    /// A service that checks if the request is HTTP/2 compatible.
+    #[derive(Debug)]
+    pub struct Http2ChecksService<S, C, B>
+    where
+        S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
+        C: Connection<B> + PoolableConnection,
+    {
+        inner: PreprocessService<S, PreprocessFn<C, B, S::Error>>,
+    }
+
+    impl<S, C, B> Clone for Http2ChecksService<S, C, B>
+    where
+        S: tower::Service<ExecuteRequest<C, B>, Error = Error> + Clone,
+        C: Connection<B> + PoolableConnection,
+    {
+        fn clone(&self) -> Self {
+            Self::new(self.inner.service().clone())
+        }
+    }
+
+    impl<S, C, B> Http2ChecksService<S, C, B>
+    where
+        S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
+        C: Connection<B> + PoolableConnection,
+    {
+        /// Create a new `Http2ChecksService`.
+        pub fn new(inner: S) -> Self {
+            Self {
+                inner: PreprocessService::new(inner, check_http2_request),
+            }
+        }
+    }
+
+    fn check_http2_request<C, B>(
+        mut req: ExecuteRequest<C, B>,
+    ) -> Result<ExecuteRequest<C, B>, Error>
+    where
+        C: Connection<B> + PoolableConnection,
+    {
+        if req.connection().version() == http::Version::HTTP_2 {
+            if req.request().method() == http::Method::CONNECT {
+                return Err(Error::InvalidMethod(http::Method::CONNECT));
+            }
+
+            *req.request_mut().version_mut() = http::Version::HTTP_2;
+
+            for connection_header in &CONNECTION_HEADERS {
+                if req
+                    .request_mut()
+                    .headers_mut()
+                    .remove(connection_header)
+                    .is_some()
+                {
+                    tracing::warn!(
+                        "removed illegal connection header {:?} from HTTP/2 request",
+                        connection_header
+                    );
+                };
+            }
+
+            if req
+                .request_mut()
+                .headers_mut()
+                .remove(http::header::HOST)
+                .is_some()
+            {
+                tracing::warn!("removed illegal header `host` from HTTP/2 request");
+            }
+        }
+        Ok(req)
+    }
+
+    impl<S, C, B> tower::Service<ExecuteRequest<C, B>> for Http2ChecksService<S, C, B>
+    where
+        S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
+        C: Connection<B> + PoolableConnection,
+    {
+        type Response = S::Response;
+
+        type Error = S::Error;
+
+        type Future = MaybeErrorFuture<S::Future, S::Response, S::Error>;
+
+        #[inline]
+        fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            self.inner.poll_ready(cx)
+        }
+
+        #[inline]
+        fn call(&mut self, req: ExecuteRequest<C, B>) -> Self::Future {
+            self.inner.call(req)
+        }
+    }
+
+    /// A `Layer` that applies HTTP/2 checks to requests.
+    pub struct Http2ChecksLayer<C, B> {
+        _marker: std::marker::PhantomData<fn(C, B)>,
+    }
+
+    impl<C, B> Http2ChecksLayer<C, B> {
+        /// Create a new `Http2ChecksLayer`.
+        pub fn new() -> Self {
+            Self {
+                _marker: std::marker::PhantomData,
+            }
+        }
+    }
+
+    impl<C, B> Default for Http2ChecksLayer<C, B> {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl<C, B> fmt::Debug for Http2ChecksLayer<C, B> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("Http2ChecksLayer").finish()
+        }
+    }
+
+    impl<C, B> Clone for Http2ChecksLayer<C, B> {
+        fn clone(&self) -> Self {
+            Self::new()
+        }
+    }
+
+    impl<S, C, B> tower::layer::Layer<S> for Http2ChecksLayer<C, B>
+    where
+        S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
+        C: Connection<B> + PoolableConnection,
+    {
+        type Service = Http2ChecksService<S, C, B>;
+
+        fn layer(&self, inner: S) -> Self::Service {
+            Http2ChecksService::new(inner)
+        }
+    }
+}
+
 #[cfg(test)]
 #[allow(dead_code)]
 mod tests {

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,5 +1,10 @@
 //! A collection of utilities for working with `Service` types and Servers.
 
+#[cfg(feature = "client")]
+pub(crate) mod client;
+mod error;
+#[cfg(feature = "client")]
+mod host;
 mod http;
 #[cfg(feature = "incoming")]
 mod incoming;
@@ -11,6 +16,15 @@ mod serviceref;
 mod shared;
 mod timeout;
 
+#[cfg(feature = "client")]
+pub use self::client::{ExecuteRequest, RequestExecutor};
+pub use self::error::{MaybeErrorFuture, PreprocessLayer, PreprocessService};
+#[cfg(feature = "client")]
+pub use self::host::{SetHostHeader, SetHostHeaderLayer};
+#[cfg(feature = "client")]
+pub use self::http::http1::{Http1ChecksLayer, Http1ChecksService};
+#[cfg(feature = "client")]
+pub use self::http::http2::{Http2ChecksLayer, Http2ChecksService};
 pub use self::http::HttpService;
 #[cfg(feature = "incoming")]
 pub use self::incoming::{AdaptIncomingLayer, AdaptIncomingService};

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -11,6 +11,8 @@ type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 #[tokio::test]
 async fn client() -> Result<(), BoxError> {
+    let _ = tracing_subscriber::fmt::try_init();
+
     let (tx, incoming) = hyperdriver::stream::duplex::pair();
 
     let acceptor: hyperdriver::server::conn::Acceptor =
@@ -38,6 +40,8 @@ async fn client() -> Result<(), BoxError> {
 
 #[tokio::test]
 async fn client_h2() -> Result<(), BoxError> {
+    let _ = tracing_subscriber::fmt::try_init();
+
     let (tx, incoming) = hyperdriver::stream::duplex::pair();
 
     let acceptor: hyperdriver::server::conn::Acceptor =


### PR DESCRIPTION
- **Split the client into service layers**
- **Refactor checkout to support continuing on drop**
- **Configure delayed drop via pool**
