### PR TITLE
Remove TransportStream

### DIFF
--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -18,7 +18,7 @@ use super::conn::transport::TransportExt;
 use super::conn::Connection;
 use super::conn::Protocol;
 use super::conn::Transport;
-use super::pool::PoolableConnection;
+use super::pool::{PoolableConnection, PoolableTransport};
 use super::ConnectionPoolLayer;
 use crate::service::RequestExecutor;
 use crate::service::{Http1ChecksLayer, Http2ChecksLayer, SetHostHeaderLayer};
@@ -380,7 +380,7 @@ where
     T: BuildTransport,
     <T as BuildTransport>::Target: Transport + Clone + Send + Sync + 'static,
     <<T as BuildTransport>::Target as Transport>::IO:
-        tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+        PoolableTransport + tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
     <<<T as BuildTransport>::Target as Transport>::IO as HasConnectionInfo>::Addr:
         Unpin + Clone + Send,
     P: BuildProtocol<
@@ -471,7 +471,7 @@ where
     T: BuildTransport,
     <T as BuildTransport>::Target: Transport + Clone + Send + Sync + 'static,
     <<T as BuildTransport>::Target as Transport>::IO:
-        tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+        PoolableTransport + tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
     <<<T as BuildTransport>::Target as Transport>::IO as HasConnectionInfo>::Addr:
         Unpin + Clone + Send,
     P: BuildProtocol<
@@ -527,6 +527,11 @@ mod tests {
 
     #[test]
     fn build_default_compiles() {
+        #[cfg(feature = "tls")]
+        {
+            crate::fixtures::tls_install_default();
+        }
+
         let _ = Builder::default().build();
     }
 }

--- a/src/client/conn/mod.rs
+++ b/src/client/conn/mod.rs
@@ -46,5 +46,5 @@ pub mod transport;
 pub use self::connection::Connection;
 pub use self::protocol::{Protocol, ProtocolRequest};
 pub use self::stream::Stream;
+pub use self::transport::Transport;
 pub use self::transport::{TlsTransport, TransportExt as _};
-pub use self::transport::{Transport, TransportStream};

--- a/src/client/conn/stream/tls.rs
+++ b/src/client/conn/stream/tls.rs
@@ -11,6 +11,7 @@ use rustls::ClientConfig;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::ToSocketAddrs;
 
+use crate::client::pool::PoolableTransport;
 use crate::info::tls::HasTlsConnectionInfo;
 use crate::info::TlsConnectionInfo;
 use crate::info::{ConnectionInfo, HasConnectionInfo};
@@ -70,6 +71,19 @@ where
 {
     fn tls_info(&self) -> Option<&TlsConnectionInfo> {
         self.tls.as_ref()
+    }
+}
+
+impl<IO> PoolableTransport for TlsStream<IO>
+where
+    IO: HasConnectionInfo + Unpin + Send + 'static,
+    IO::Addr: Clone + Unpin + Send,
+{
+    fn can_share(&self) -> bool {
+        match self.tls.as_ref() {
+            Some(info) => info.can_share(),
+            None => false,
+        }
     }
 }
 

--- a/src/client/conn/transport/duplex.rs
+++ b/src/client/conn/transport/duplex.rs
@@ -6,7 +6,6 @@ use std::task::{Context, Poll};
 use futures_util::future::BoxFuture;
 use http::Uri;
 
-use super::TransportStream;
 use crate::stream::duplex::DuplexStream as Stream;
 
 /// Transport via duplex stream
@@ -27,11 +26,11 @@ impl DuplexTransport {
 }
 
 impl tower::Service<Uri> for DuplexTransport {
-    type Response = TransportStream<Stream>;
+    type Response = Stream;
 
     type Error = io::Error;
 
-    type Future = BoxFuture<'static, Result<TransportStream<Stream>, io::Error>>;
+    type Future = BoxFuture<'static, Result<Stream, io::Error>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
@@ -42,11 +41,7 @@ impl tower::Service<Uri> for DuplexTransport {
         let max_buf_size = self.max_buf_size;
         let fut = async move {
             let stream = client.connect(max_buf_size).await?;
-            Ok(TransportStream::new(
-                stream,
-                #[cfg(feature = "tls")]
-                None,
-            ))
+            Ok(stream)
         };
 
         Box::pin(fut)

--- a/src/client/conn/transport/mock.rs
+++ b/src/client/conn/transport/mock.rs
@@ -1,13 +1,11 @@
 //! A transport full of empty implementations, suitable for testing behavior of transport-dependent code.
 
-use std::future::{ready, Future, Ready};
+use std::future::{ready, Future};
 
 use thiserror::Error;
 
-use crate::client::conn::stream::mock::MockStream;
-use crate::client::pool::PoolableTransport;
-
-use super::TransportStream;
+use crate::client::conn::stream::mock::{MockConnection, MockStream};
+use crate::client::pool::{self};
 
 type BoxFuture<'a, T> = std::pin::Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
@@ -16,22 +14,30 @@ type BoxFuture<'a, T> = std::pin::Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 #[error("connection error")]
 pub struct MockConnectionError;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug)]
 enum TransportMode {
     SingleUse,
     Reusable,
     ConnectionError,
+    Channel(tokio::sync::oneshot::Receiver<MockStream>),
 }
 
 /// A mock transport that can be used to test connection behavior.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct MockTransport {
     mode: TransportMode,
 }
 
-impl PoolableTransport for MockTransport {
-    fn can_share(&self) -> bool {
-        matches!(self.mode, TransportMode::Reusable)
+impl Clone for MockTransport {
+    fn clone(&self) -> Self {
+        Self {
+            mode: match &self.mode {
+                TransportMode::Channel(_) => TransportMode::ConnectionError,
+                TransportMode::SingleUse => TransportMode::SingleUse,
+                TransportMode::Reusable => TransportMode::Reusable,
+                TransportMode::ConnectionError => TransportMode::ConnectionError,
+            },
+        }
     }
 }
 
@@ -47,39 +53,50 @@ impl MockTransport {
     }
 
     /// Transport which can be used only once
-    pub fn single() -> Ready<Result<Self, MockConnectionError>> {
-        ready(Ok(Self::new(false)))
+    pub fn single() -> Self {
+        Self::new(false)
     }
 
     /// Transport which can be reused
-    pub fn reusable() -> Ready<Result<Self, MockConnectionError>> {
-        ready(Ok(Self::new(true)))
-    }
-
-    /// Return a future representing the completion of the connection handshake.
-    ///
-    /// This must return a boxed future for compatibility with the underlying
-    /// pool.
-    pub fn handshake(self) -> BoxFuture<'static, Result<MockStream, MockConnectionError>> {
-        let reuse = matches!(self.mode, TransportMode::Reusable);
-        Box::pin(ready(Ok(MockStream::new(reuse))))
+    pub fn reusable() -> Self {
+        Self::new(true)
     }
 
     /// Transport which returns an error during connection attempts
-    pub fn error() -> Ready<Result<Self, MockConnectionError>> {
-        ready(Err(MockConnectionError))
-    }
-
-    /// Transport which immediately returns an error.
-    pub fn connection_error() -> Self {
+    pub fn error() -> Self {
         Self {
             mode: TransportMode::ConnectionError,
         }
     }
+
+    /// Transport which returns a stream from a oneshot channel
+    pub fn channel(rx: tokio::sync::oneshot::Receiver<MockStream>) -> Self {
+        Self {
+            mode: TransportMode::Channel(rx),
+        }
+    }
+
+    /// Create a new connector for the transport.
+    pub fn connector(self) -> pool::Connector<MockConnection, MockStream, MockConnectionError> {
+        let connect: BoxFuture<'static, Result<MockStream, MockConnectionError>> = match self.mode {
+            TransportMode::SingleUse => Box::pin(ready(Ok(MockStream::single()))) as _,
+            TransportMode::Reusable => Box::pin(ready(Ok(MockStream::reusable()))) as _,
+            TransportMode::ConnectionError => Box::pin(ready(Err(MockConnectionError))) as _,
+            TransportMode::Channel(rx) => Box::pin(async move {
+                Ok(rx
+                    .await
+                    .expect("mock channel closed before stream was received"))
+            }) as _,
+        };
+
+        let handshake = move |stream| Box::pin(ready(Ok(MockConnection::new(stream)))) as _;
+
+        pool::Connector::new(move || connect, handshake)
+    }
 }
 
 impl tower::Service<http::Uri> for MockTransport {
-    type Response = TransportStream<MockStream>;
+    type Response = MockStream;
 
     type Error = MockConnectionError;
 
@@ -97,16 +114,11 @@ impl tower::Service<http::Uri> for MockTransport {
             TransportMode::SingleUse => false,
             TransportMode::Reusable => true,
             TransportMode::ConnectionError => return Box::pin(ready(Err(MockConnectionError))),
+            TransportMode::Channel(_) => return Box::pin(ready(Err(MockConnectionError))),
         };
 
         let conn = MockStream::new(reuse);
-        Box::pin(async move {
-            Ok(TransportStream::new(
-                conn,
-                #[cfg(feature = "tls")]
-                None,
-            ))
-        })
+        Box::pin(async move { Ok(conn) })
     }
 }
 

--- a/src/client/pool/checkout.rs
+++ b/src/client/pool/checkout.rs
@@ -439,10 +439,9 @@ mod test {
     async fn detatched_checkout() {
         let key: Key = "http://localhost:8080".parse().unwrap();
 
-        let checkout = Checkout::detached(
-            key,
-            Connector::new(MockTransport::single, MockTransport::handshake),
-        );
+        let transport = MockTransport::single();
+
+        let checkout = Checkout::detached(key, transport.connector());
 
         let dbg = format!("{:?}", checkout);
         assert_eq!(

--- a/src/client/pool/idle.rs
+++ b/src/client/pool/idle.rs
@@ -96,11 +96,11 @@ mod test {
     use std::thread;
 
     use super::*;
-    use crate::client::conn::stream::mock::MockStream;
+    use crate::client::conn::stream::mock::MockConnection;
 
     #[test]
     fn verify_idle() {
-        let conn = MockStream::single();
+        let conn = MockConnection::single();
         let idle = Idle::new(conn);
 
         let dbg = format!("{:?}", idle);
@@ -115,7 +115,7 @@ mod test {
 
         assert_eq!(format!("{:?}", idle), "IdleConnections { inner: [] }");
 
-        let conn = MockStream::single();
+        let conn = MockConnection::single();
         idle.push(conn);
 
         assert_eq!(idle.len(), 1);
@@ -132,9 +132,9 @@ mod test {
         let mut idle = IdleConnections::default();
         assert_eq!(idle.len(), 0);
 
-        let conn1 = MockStream::single();
-        let conn2 = MockStream::single();
-        let conn3 = MockStream::single();
+        let conn1 = MockConnection::single();
+        let conn2 = MockConnection::single();
+        let conn3 = MockConnection::single();
 
         idle.push(conn1);
         idle.push(conn2);
@@ -164,9 +164,9 @@ mod test {
         let mut idle = IdleConnections::default();
         assert_eq!(idle.len(), 0);
 
-        let conn1 = MockStream::single();
-        let conn2 = MockStream::single();
-        let conn3 = MockStream::single();
+        let conn1 = MockConnection::single();
+        let conn2 = MockConnection::single();
+        let conn3 = MockConnection::single();
 
         idle.push(conn1);
         idle.push(conn2);
@@ -196,9 +196,9 @@ mod test {
         let mut idle = IdleConnections::default();
         assert_eq!(idle.len(), 0);
 
-        let conn1 = MockStream::single();
-        let conn2 = MockStream::single();
-        let conn3 = MockStream::single();
+        let conn1 = MockConnection::single();
+        let conn2 = MockConnection::single();
+        let conn3 = MockConnection::single();
 
         idle.push(conn1);
         idle.push(conn2);

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -300,6 +300,13 @@ pub trait HasConnectionInfo {
     fn info(&self) -> ConnectionInfo<Self::Addr>;
 }
 
+#[cfg(not(feature = "tls"))]
+/// Trait for types which can provide TLS connection information, not populated without the `tls` feature.
+pub trait HasTlsConnectionInfo {}
+
+#[cfg(not(feature = "tls"))]
+impl<T> HasTlsConnectionInfo for T where T: HasConnectionInfo {}
+
 #[cfg(test)]
 mod tests {
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};

--- a/src/info/tls.rs
+++ b/src/info/tls.rs
@@ -56,6 +56,12 @@ impl TlsConnectionInfo {
         }
     }
 
+    #[cfg_attr(not(all(feature = "tls", feature = "client")), allow(dead_code))]
+    pub(crate) fn can_share(&self) -> bool {
+        self.alpn == Some(Protocol::Http(http::Version::HTTP_2))
+            || self.alpn == Some(Protocol::Http(http::Version::HTTP_3))
+    }
+
     #[cfg(test)]
     #[allow(dead_code)]
     pub(crate) fn new_server(
@@ -186,10 +192,13 @@ mod channel {
 
 #[cfg(test)]
 mod tests {
+    use crate::fixtures;
     use std::sync::Arc;
 
     #[test]
     fn tls_server_info() {
+        fixtures::tls_install_default();
+
         #[derive(Debug, Clone)]
         struct NoCertResolver;
 
@@ -215,6 +224,8 @@ mod tests {
 
     #[test]
     fn tls_client_info() {
+        fixtures::tls_install_default();
+
         let root_store = rustls::RootCertStore {
             roots: webpki_roots::TLS_SERVER_ROOTS.into(),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,4 +225,21 @@ pub(crate) mod fixtures {
         config.alpn_protocols.push(b"http/1.1".to_vec());
         config
     }
+
+    pub(crate) fn tls_install_default() {
+        #[cfg(feature = "tls-ring")]
+        {
+            let _ = rustls::crypto::ring::default_provider().install_default();
+        }
+
+        #[cfg(all(feature = "tls-aws-lc", not(feature = "tls-ring")))]
+        {
+            let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        }
+
+        #[cfg(not(any(feature = "tls-aws-lc", feature = "tls-ring")))]
+        {
+            panic!("No TLS backend enabled, please enable one of `tls-ring` or `tls-aws-lc`");
+        }
+    }
 }

--- a/src/server/conn/tls/info.rs
+++ b/src/server/conn/tls/info.rs
@@ -184,6 +184,8 @@ mod tests {
     use tower::make::Shared;
     use tower::Service;
 
+    use crate::fixtures;
+
     use crate::client::conn::transport::duplex::DuplexTransport;
     use crate::client::conn::transport::TransportExt as _;
     use crate::client::conn::Transport as _;
@@ -196,6 +198,7 @@ mod tests {
     async fn tls_server_info() {
         let _ = tracing_subscriber::fmt::try_init();
         let _ = color_eyre::install();
+        fixtures::tls_install_default();
 
         let _guard = tracing::info_span!("tls").entered();
 
@@ -214,14 +217,13 @@ mod tests {
             .with_tls(crate::fixtures::tls_client_config().into());
 
         let client = async move {
-            let conn = client
+            let mut stream = client
                 .connect("https://example.com".parse().unwrap())
                 .await
                 .unwrap();
 
             tracing::debug!("client connected");
 
-            let (mut stream, _) = conn.into_parts();
             stream.finish_handshake().await.unwrap();
 
             tracing::debug!("client handshake finished");

--- a/src/server/conn/tls/mod.rs
+++ b/src/server/conn/tls/mod.rs
@@ -193,6 +193,8 @@ mod tests {
 
     use tracing::Instrument as _;
 
+    use crate::fixtures;
+
     use crate::client::conn::transport::duplex::DuplexTransport;
     use crate::client::conn::transport::TransportExt as _;
     use crate::client::conn::Transport as _;
@@ -203,6 +205,7 @@ mod tests {
     async fn tls_client_server() {
         let _ = tracing_subscriber::fmt::try_init();
         let _ = color_eyre::install();
+        fixtures::tls_install_default();
 
         let _guard = tracing::info_span!("tls").entered();
 
@@ -219,14 +222,13 @@ mod tests {
             .with_tls(crate::fixtures::tls_client_config().into());
 
         let client = async move {
-            let conn = client
+            let mut stream = client
                 .connect("https://example.com".parse().unwrap())
                 .await
                 .unwrap();
 
             tracing::debug!("client connected");
 
-            let (mut stream, _) = conn.into_parts();
             stream.finish_handshake().await.unwrap();
 
             tracing::debug!("client handshake finished");

--- a/src/service/client.rs
+++ b/src/service/client.rs
@@ -183,7 +183,7 @@ mod tests {
     async fn test_client_mock_connection_error() {
         use crate::client::{conn::connection::ConnectionError, ConnectionPoolService};
 
-        let transport = MockTransport::connection_error();
+        let transport = MockTransport::error();
         let protocol = MockProtocol::default();
         let pool = PoolConfig::default();
 

--- a/src/stream/duplex.rs
+++ b/src/stream/duplex.rs
@@ -102,6 +102,13 @@ impl DuplexStream {
     }
 }
 
+#[cfg(feature = "client")]
+impl crate::client::pool::PoolableTransport for DuplexStream {
+    fn can_share(&self) -> bool {
+        false
+    }
+}
+
 impl AsyncRead for DuplexStream {
     fn poll_read(
         self: std::pin::Pin<&mut Self>,

--- a/src/stream/tcp.rs
+++ b/src/stream/tcp.rs
@@ -136,6 +136,13 @@ impl HasConnectionInfo for TcpStream {
     }
 }
 
+#[cfg(feature = "client")]
+impl crate::client::pool::PoolableTransport for TcpStream {
+    fn can_share(&self) -> bool {
+        false
+    }
+}
+
 impl AsyncRead for TcpStream {
     fn poll_read(
         self: Pin<&mut Self>,

--- a/src/stream/tls.rs
+++ b/src/stream/tls.rs
@@ -80,6 +80,20 @@ where
     }
 }
 
+#[cfg(feature = "client")]
+impl<Tls, NoTls> crate::client::pool::PoolableTransport for TlsBraid<Tls, NoTls>
+where
+    Tls: TlsHandshakeStream + Unpin + 'static,
+    NoTls: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+{
+    fn can_share(&self) -> bool {
+        match self {
+            TlsBraid::NoTls(_) => false,
+            TlsBraid::Tls(_) => true,
+        }
+    }
+}
+
 macro_rules! dispatch {
     ($driver:ident.$method:ident($($args:expr),+)) => {
 

--- a/src/stream/unix.rs
+++ b/src/stream/unix.rs
@@ -202,6 +202,13 @@ impl HasConnectionInfo for UnixStream {
     }
 }
 
+#[cfg(feature = "client")]
+impl crate::client::pool::PoolableTransport for UnixStream {
+    fn can_share(&self) -> bool {
+        false
+    }
+}
+
 impl AsyncRead for UnixStream {
     fn poll_read(
         self: Pin<&mut Self>,

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -32,13 +32,7 @@ async fn connection<P: hyperdriver::client::conn::Protocol<Stream, hyperdriver::
     mut protocol: P,
 ) -> Result<P::Connection, Box<dyn std::error::Error>> {
     let stream = client.connect(1024).await?;
-    let conn = protocol
-        .connect(
-            hyperdriver::client::conn::transport::TransportStream::new_stream(stream.into())
-                .await?,
-            HttpProtocol::Http1,
-        )
-        .await?;
+    let conn = protocol.connect(stream.into(), HttpProtocol::Http1).await?;
     Ok(conn)
 }
 

--- a/tests/stream/tls.rs
+++ b/tests/stream/tls.rs
@@ -31,10 +31,16 @@ fn tls_root_store() -> rustls::RootCertStore {
     root_store
 }
 
+fn tls_install_default() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
 #[tokio::test]
 async fn braided_tls() {
     use futures_util::StreamExt;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    tls_install_default();
 
     let incoming = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
         .await

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -44,6 +44,10 @@ fn tls_root_store() -> rustls::RootCertStore {
     root_store
 }
 
+fn tls_install_default() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
 async fn echo(req: http::Request<Body>) -> Result<http::Response<Body>, BoxError> {
     tracing::trace!("processing request");
     let body = req.into_body();
@@ -85,6 +89,7 @@ async fn tls_echo_h1() {
     use hyperdriver::client::conn::transport::duplex::DuplexTransport;
     use hyperdriver::Client;
 
+    tls_install_default();
     let _ = tracing_subscriber::fmt::try_init();
 
     let (duplex_client, incoming) = hyperdriver::stream::duplex::pair();
@@ -137,6 +142,7 @@ async fn tls_echo_h2() {
     use hyperdriver::client::conn::transport::duplex::DuplexTransport;
     use hyperdriver::Client;
 
+    tls_install_default();
     let _ = tracing_subscriber::fmt::try_init();
 
     let (duplex_client, incoming) = hyperdriver::stream::duplex::pair();


### PR DESCRIPTION
TransportStream is effectively a crutch to handle TLS and non-TLS streams
in different features. Instead, we can use plain IO types, and just require
that they implement HasTlsConnectionInfo trait. When the TLS feature is
disabled, this trait is blanket implemented for every type.

fix: Fix mock connections and transport to be more consistent.
