### PR TITLE
bugfix: delayed drop could duplicate connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
  "tokio",
- "tower 0.4.13",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -671,7 +671,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-rustls",
- "tower 0.5.1",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -1501,21 +1501,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project-lite",
- "sync_wrapper 0.1.2",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "tower-http"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,7 +1514,7 @@ dependencies = [
  "http-body-util",
  "iri-string",
  "pin-project-lite",
- "tower 0.4.13",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ default-features = false
 optional = true
 
 [dependencies.tower]
-version = "0.5"
+version = "0.4"
 features = ["make", "util"]
 default-features = false
 

--- a/src/client/pool/service.rs
+++ b/src/client/pool/service.rs
@@ -256,8 +256,10 @@ where
         );
 
         if let Some(pool) = self.pool.as_ref() {
+            tracing::trace!(%key, "checking out connection");
             Ok(pool.checkout(key, http_protocol.multiplex(), connector))
         } else {
+            tracing::trace!(%key, "detatched connection");
             Ok(Checkout::detached(key, connector))
         }
     }


### PR DESCRIPTION
When delayed drop happens, if the conenction is not in the Connected state, then it would continue to attempt a connection. When the handshake finishes, the Checkout object was not setting the state to Connected, and instead just returning. Fixing this ensures that connections aren’t re-attempted.

Additionally, checkouts would register waiters for themselves, and then wait for their own connection to be ready. To avoid this, checkouts now close their waiter when their connection is ready and they start the registration process. This means they will be skipped in the pass through the waiters in register_connection.
