### PR TITLE
fix/service replace

### DIFF
--- a/src/client/conn/protocol/auto.rs
+++ b/src/client/conn/protocol/auto.rs
@@ -178,7 +178,8 @@ where
 
     #[tracing::instrument("http-connect", skip_all, fields(addr=?req.transport.info().remote_addr()))]
     fn call(&mut self, req: ProtocolRequest<IO, B>) -> Self::Future {
-        future::HttpConnectFuture::new(self.clone(), req.transport, req.version)
+        let builder = std::mem::replace(self, self.clone());
+        future::HttpConnectFuture::new(builder, req.transport, req.version)
     }
 }
 

--- a/src/client/conn/protocol/mod.rs
+++ b/src/client/conn/protocol/mod.rs
@@ -177,7 +177,7 @@ where
     }
 
     fn call(&mut self, req: ProtocolRequest<IO, B>) -> Self::Future {
-        let builder = self.clone();
+        let builder = std::mem::replace(self, self.clone());
         let stream = req.transport;
 
         let info = stream.info();
@@ -232,7 +232,7 @@ where
     }
 
     fn call(&mut self, req: ProtocolRequest<IO, BIn>) -> Self::Future {
-        let builder = self.clone();
+        let builder = std::mem::replace(self, self.clone());
         let stream = req.transport;
         let info = stream.info();
         let span = tracing::info_span!("connection", version=?http::Version::HTTP_11, peer=%info.remote_addr());

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -184,6 +184,7 @@ impl tower::Service<http::Request<crate::Body>> for Client {
     >;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        //TODO: What happens if we poll_ready, then clone, then call? The wrong (not ready) service will be used.
         Arc::make_mut(&mut self.inner).service.poll_ready(cx)
     }
 

--- a/src/server/conn/info.rs
+++ b/src/server/conn/info.rs
@@ -92,13 +92,14 @@ where
 
     fn poll_ready(
         &mut self,
-        _cx: &mut std::task::Context<'_>,
+        cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
+        self.inner.poll_ready(cx)
     }
 
     fn call(&mut self, stream: &IO) -> Self::Future {
-        let mut inner = self.inner.clone();
+        let inner = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, inner);
         let info = stream.info();
         future::MakeServiceConnectionInfoFuture::new(inner.call(stream), info)
     }

--- a/src/server/conn/tls/info.rs
+++ b/src/server/conn/tls/info.rs
@@ -58,13 +58,14 @@ where
 
     fn poll_ready(
         &mut self,
-        _cx: &mut std::task::Context<'_>,
+        cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
+        self.inner.poll_ready(cx)
     }
 
     fn call(&mut self, stream: &IO) -> Self::Future {
-        let mut inner = self.inner.clone();
+        let inner = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, inner);
         let rx = stream.recv();
         future::TlsConnectionFuture::new(inner.call(stream), rx)
     }


### PR DESCRIPTION
- **bugfix: TCP address resolver must be clone and replaced in the transport service**
- **fix: Ensure that services polled to readiness are used directly**
