### PR TITLE
feat: Client pool can delay drop for checkout

### DIFF
--- a/src/client/pool/service.rs
+++ b/src/client/pool/service.rs
@@ -177,7 +177,7 @@ impl
             pool: Some(pool::Pool::new(pool::Config {
                 idle_timeout: Some(std::time::Duration::from_secs(90)),
                 max_idle_per_host: 32,
-                continue_after_premeption: true,
+                continue_after_preemption: true,
             })),
 
             transport: Default::default(),

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -294,7 +294,7 @@ impl<Addr> ConnectionInfo<Addr> {
 /// Trait for types which can provide connection information.
 pub trait HasConnectionInfo {
     /// The address type for this connection.
-    type Addr: fmt::Display + fmt::Debug;
+    type Addr: fmt::Display + fmt::Debug + Send;
 
     /// Get the connection information for this stream.
     fn info(&self) -> ConnectionInfo<Self::Addr>;


### PR DESCRIPTION
When a checkout gets interrupted by a ready / idle connection, the checkout may have done significant work to create the connection. In delayed drop mode, instead of cancelling the connection attempt, the connection will continue in the background and then be added to the pool as a new idle connection.

This can save significant time when future connections begin. The downside is that it requires heap-allocating the future for the connector, but this penalty should be small compared to the typical network latencies observed and the potential savings (100s of ms) by not throwing away completed connection work.
