### PR TITLE
Refactor to a single BoxError and BoxFuture

### DIFF
--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -22,6 +22,7 @@ use super::pool::{PoolableConnection, PoolableStream};
 use super::ConnectionPoolLayer;
 use crate::service::RequestExecutor;
 use crate::service::{Http1ChecksLayer, Http2ChecksLayer, SetHostHeaderLayer};
+use crate::BoxError;
 
 use crate::client::conn::connection::ConnectionError;
 #[cfg(feature = "tls")]
@@ -419,7 +420,7 @@ where
     <S::Service as tower::Service<http::Request<BIn>>>::Future: Send + 'static,
     BIn: Default + Body + Unpin + Send + 'static,
     <BIn as Body>::Data: Send,
-    <BIn as Body>::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    <BIn as Body>::Error: Into<BoxError>,
     BOut: From<hyper::body::Incoming> + Body + Unpin + Send + 'static,
 {
     /// Build a client service with the configured layers

--- a/src/client/conn/connection.rs
+++ b/src/client/conn/connection.rs
@@ -3,7 +3,7 @@
 
 use std::{fmt, future::Future};
 
-use futures_core::future::BoxFuture;
+use crate::BoxFuture;
 use futures_util::FutureExt as _;
 use http_body::Body as HttpBody;
 use hyper::body::Incoming;

--- a/src/client/conn/protocol/mod.rs
+++ b/src/client/conn/protocol/mod.rs
@@ -7,7 +7,7 @@
 use std::future::Future;
 use std::marker::PhantomData;
 
-use futures_core::future::BoxFuture;
+use crate::BoxFuture;
 use http_body::Body;
 use tokio::io::AsyncRead;
 use tokio::io::AsyncWrite;
@@ -18,6 +18,7 @@ use super::connection::HttpConnection;
 use super::Connection;
 use crate::bridge::io::TokioIo;
 use crate::info::HasConnectionInfo;
+use crate::BoxError;
 
 pub mod auto;
 #[cfg(feature = "mocks")]
@@ -161,7 +162,7 @@ where
     IO: HasConnectionInfo + AsyncRead + AsyncWrite + Send + Unpin + 'static,
     B: Body + Unpin + Send + 'static,
     <B as Body>::Data: Send,
-    <B as Body>::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    <B as Body>::Error: Into<BoxError>,
 {
     type Response = HttpConnection<B>;
 
@@ -213,7 +214,7 @@ where
     IO: HasConnectionInfo + AsyncRead + AsyncWrite + Send + Unpin + 'static,
     BIn: Body + Unpin + Send + 'static,
     <BIn as Body>::Data: Send,
-    <BIn as Body>::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    <BIn as Body>::Error: Into<BoxError>,
 {
     type Response = HttpConnection<BIn>;
 

--- a/src/client/conn/transport/duplex.rs
+++ b/src/client/conn/transport/duplex.rs
@@ -3,7 +3,7 @@
 use std::io;
 use std::task::{Context, Poll};
 
-use futures_util::future::BoxFuture;
+use crate::BoxFuture;
 use http::Uri;
 
 use crate::stream::duplex::DuplexStream as Stream;

--- a/src/client/conn/transport/mock.rs
+++ b/src/client/conn/transport/mock.rs
@@ -1,6 +1,6 @@
 //! A transport full of empty implementations, suitable for testing behavior of transport-dependent code.
 
-use std::future::{ready, Future};
+use std::future::ready;
 
 use http::Uri;
 use thiserror::Error;
@@ -9,8 +9,7 @@ use crate::client::conn::protocol::mock::MockProtocol;
 use crate::client::conn::protocol::HttpProtocol;
 use crate::client::conn::stream::mock::MockStream;
 use crate::client::pool::{self};
-
-type BoxFuture<'a, T> = std::pin::Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+use crate::BoxFuture;
 
 /// An error that can occur when creating a mock transport.
 #[derive(Debug, Error, PartialEq, Eq)]

--- a/src/client/conn/transport/tcp.rs
+++ b/src/client/conn/transport/tcp.rs
@@ -14,7 +14,6 @@ use std::future::Future;
 use std::io;
 use std::marker::PhantomData;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
-use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
@@ -32,6 +31,7 @@ use crate::client::conn::dns::{GaiResolver, IpVersion, SocketAddrs};
 use crate::happy_eyeballs::{EyeballSet, HappyEyeballsError};
 use crate::info::HasConnectionInfo;
 use crate::stream::tcp::TcpStream;
+use crate::BoxError;
 
 /// A TCP connector for client connections.
 ///
@@ -167,7 +167,7 @@ impl<R, IO> TcpTransport<R, IO> {
     }
 }
 
-type BoxFuture<'a, T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'a>>;
+type BoxFuture<'a, T, E> = crate::BoxFuture<'a, Result<T, E>>;
 
 impl<R, IO> tower::Service<Uri> for TcpTransport<R, IO>
 where
@@ -371,7 +371,7 @@ pub struct InvalidUri {
 pub struct TcpConnectionError {
     message: String,
     #[source]
-    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+    source: Option<BoxError>,
 }
 
 impl TcpConnectionError {

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -1,6 +1,7 @@
 use thiserror::Error;
 
-use super::{pool, BoxError};
+use super::pool;
+use crate::BoxError;
 
 /// Client error type.
 #[derive(Debug, Error)]
@@ -61,5 +62,5 @@ mod tests {
 
     use static_assertions::assert_impl_all;
 
-    assert_impl_all!(Error: std::error::Error, Send, Sync, Into<Box<dyn std::error::Error + Send + Sync>>);
+    assert_impl_all!(Error: std::error::Error, Send, Sync, Into<BoxError>);
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -24,6 +24,7 @@ use self::conn::transport::tcp::TcpTransportConfig;
 pub use self::pool::service::ConnectionPoolLayer;
 pub use self::pool::service::ConnectionPoolService;
 use crate::service::SharedService;
+use crate::BoxError;
 
 mod builder;
 pub mod conn;
@@ -33,8 +34,6 @@ pub mod pool;
 pub use self::error::Error;
 pub use self::pool::Config as PoolConfig;
 pub use builder::Builder;
-
-type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 #[cfg(feature = "tls")]
 /// Get a default TLS client configuration by loading the platform's native certificates.

--- a/src/client/pool/checkout.rs
+++ b/src/client/pool/checkout.rs
@@ -726,10 +726,11 @@ mod test {
 
     use static_assertions::assert_impl_all;
 
-    assert_impl_all!(Error<std::io::Error, std::io::Error>: std::error::Error, Send, Sync, Into<Box<dyn std::error::Error + Send + Sync>>);
+    assert_impl_all!(Error<std::io::Error, std::io::Error>: std::error::Error, Send, Sync, Into<BoxError>);
 
     #[cfg(feature = "mocks")]
     use crate::client::conn::transport::mock::MockTransport;
+    use crate::BoxError;
 
     #[test]
     fn verify_checkout_id() {

--- a/src/client/pool/service.rs
+++ b/src/client/pool/service.rs
@@ -20,10 +20,10 @@ use crate::client::pool;
 use crate::client::pool::Checkout;
 use crate::client::pool::Connector;
 use crate::client::pool::PoolableConnection;
-use crate::client::BoxError;
 use crate::client::Error;
 use crate::info::HasConnectionInfo;
 use crate::service::client::ExecuteRequest;
+use crate::BoxError;
 
 use super::PoolableStream;
 
@@ -259,7 +259,7 @@ where
     BOut: Body + Unpin + 'static,
     BIn: Body + Unpin + Send + 'static,
     <BIn as Body>::Data: Send,
-    <BIn as Body>::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    <BIn as Body>::Error: Into<BoxError>,
 {
     type Response = http::Response<BOut>;
     type Error = Error;
@@ -298,7 +298,7 @@ where
     S::Error: Into<Error>,
     BIn: Body + Unpin + Send + 'static,
     <BIn as Body>::Data: Send,
-    <BIn as Body>::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    <BIn as Body>::Error: Into<BoxError>,
     BOut: Body + Unpin + 'static,
     <<T as Transport>::IO as HasConnectionInfo>::Addr: Send,
 {
@@ -375,7 +375,7 @@ where
     BOut: Body + Unpin + 'static,
     BIn: Body + Unpin + Send + 'static,
     <BIn as Body>::Data: Send,
-    <BIn as Body>::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    <BIn as Body>::Error: Into<BoxError>,
 {
     type Output = Result<http::Response<BOut>, Error>;
 

--- a/src/happy_eyeballs.rs
+++ b/src/happy_eyeballs.rs
@@ -11,7 +11,7 @@ use std::future::IntoFuture;
 use std::time::Instant;
 use std::{fmt, future::Future, marker::PhantomData, time::Duration};
 
-use futures_core::future::BoxFuture;
+use crate::BoxFuture;
 use futures_util::stream::FuturesUnordered;
 use futures_util::StreamExt;
 use tokio::time::error::Elapsed;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@
 
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-use std::fmt;
+use std::{fmt, future::Future, pin::Pin};
 
 use tracing::dispatcher;
 
@@ -134,6 +134,9 @@ pub use body::Body;
 pub use client::Client;
 #[cfg(feature = "server")]
 pub use server::Server;
+
+type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 /// Utility struct for formatting a `Display` type in a `Debug` context.
 #[allow(unused)]

--- a/src/server/conn/auto.rs
+++ b/src/server/conn/auto.rs
@@ -15,6 +15,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::rewind::Rewind;
 use crate::server::Protocol;
+use crate::BoxError;
 
 use super::connecting::Connecting;
 use super::{http1, http2, Connection, ConnectionError};
@@ -74,9 +75,9 @@ impl<E> Builder<E> {
     where
         S: hyper::service::HttpService<body::Incoming, ResBody = B> + Clone,
         S::Future: 'static,
-        S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+        S::Error: Into<BoxError>,
         B: Body + 'static,
-        // B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+        // B::Error: Into<BoxError>,
         I: Read + Write + Unpin + Send + 'static,
     {
         UpgradableConnection {
@@ -93,11 +94,11 @@ impl<S, IO, BIn, BOut> Protocol<S, IO, BIn> for Builder<TokioExecutor>
 where
     S: tower::Service<http::Request<BIn>, Response = http::Response<BOut>> + Clone + Send + 'static,
     S::Future: Send + 'static,
-    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    S::Error: Into<BoxError>,
     BIn: From<hyper::body::Incoming> + 'static,
     BOut: http_body::Body + Send + 'static,
     BOut::Data: Send + 'static,
-    BOut::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    BOut::Error: Into<BoxError>,
     IO: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     type ResponseBody = BOut;
@@ -124,9 +125,9 @@ impl<'b, I, S, Executor, B> Connection for UpgradableConnection<'b, I, S, Execut
 where
     S: hyper::service::HttpService<hyper::body::Incoming, ResBody = B> + Clone,
     S::Future: 'static,
-    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    S::Error: Into<BoxError>,
     B: Body + 'static,
-    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    B::Error: Into<BoxError>,
     I: Read + Write + Unpin + Send + 'static,
     Executor: Http2ServerConnExec<S::Future, B>,
 {
@@ -146,9 +147,9 @@ impl<'b, I, S, E, B> Future for UpgradableConnection<'b, I, S, E>
 where
     S: hyper::service::HttpService<hyper::body::Incoming, ResBody = B> + Clone,
     S::Future: 'static,
-    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    S::Error: Into<BoxError>,
     B: Body + 'static,
-    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    B::Error: Into<BoxError>,
     I: Read + Write + Unpin + Send + 'static,
     E: Http2ServerConnExec<S::Future, B>,
 {

--- a/src/server/conn/connecting.rs
+++ b/src/server/conn/connecting.rs
@@ -15,6 +15,7 @@ use crate::body::IncomingRequestService;
 use crate::bridge::io::TokioIo;
 use crate::bridge::rt::TokioExecutor;
 use crate::bridge::service::TowerHyperService;
+use crate::BoxError;
 
 type Connection<'a, S, IO, BIn, BOut> = UpgradableConnection<
     'a,
@@ -30,7 +31,7 @@ pub struct Connecting<S, IO, BIn, BOut>
 where
     S: tower::Service<http::Request<BIn>, Response = http::Response<BOut>> + Clone + Send + 'static,
     S::Future: Send + 'static,
-    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    S::Error: Into<BoxError>,
     BIn: From<hyper::body::Incoming>,
     BOut: http_body::Body,
 {
@@ -45,7 +46,7 @@ impl<S, IO, BIn, BOut> Connecting<S, IO, BIn, BOut>
 where
     S: tower::Service<http::Request<BIn>, Response = http::Response<BOut>> + Clone + Send + 'static,
     S::Future: Send + 'static,
-    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    S::Error: Into<BoxError>,
     BIn: From<hyper::body::Incoming> + 'static,
     BOut: http_body::Body + 'static,
     IO: AsyncRead + AsyncWrite + Send + Unpin + 'static,
@@ -64,11 +65,11 @@ impl<S, IO, BIn, BOut> crate::server::Connection for Connecting<S, IO, BIn, BOut
 where
     S: tower::Service<http::Request<BIn>, Response = http::Response<BOut>> + Clone + Send + 'static,
     S::Future: Send + 'static,
-    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    S::Error: Into<BoxError>,
     BIn: From<hyper::body::Incoming> + 'static,
     BOut: http_body::Body + Send + 'static,
     BOut::Data: Send + 'static,
-    BOut::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    BOut::Error: Into<BoxError>,
     IO: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     fn graceful_shutdown(mut self: Pin<&mut Self>) {
@@ -80,11 +81,11 @@ impl<S, IO, BIn, BOut> Future for Connecting<S, IO, BIn, BOut>
 where
     S: tower::Service<http::Request<BIn>, Response = http::Response<BOut>> + Clone + Send + 'static,
     S::Future: Send + 'static,
-    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    S::Error: Into<BoxError>,
     BIn: From<hyper::body::Incoming> + 'static,
     BOut: http_body::Body + Send + 'static,
     BOut::Data: Send + 'static,
-    BOut::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    BOut::Error: Into<BoxError>,
     IO: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     type Output = Result<(), ConnectionError>;

--- a/src/server/conn/mod.rs
+++ b/src/server/conn/mod.rs
@@ -14,6 +14,7 @@ use tokio::io::AsyncRead;
 use tokio::io::AsyncWrite;
 
 use crate::server::Protocol;
+use crate::BoxError;
 pub use acceptor::Acceptor;
 #[cfg(feature = "stream")]
 pub use acceptor::AcceptorCore;
@@ -40,7 +41,7 @@ pub enum ConnectionError {
 
     /// An error occurred in the internal service used to handle requests.
     #[error("service: {0}")]
-    Service(#[source] Box<dyn std::error::Error + Send + Sync>),
+    Service(#[source] BoxError),
 
     /// An error occurred while handling the protocol or upgrading the connection.
     #[error("protocol: {0}")]
@@ -60,10 +61,10 @@ impl<S, IO, BIn, BOut> Connection
 where
     S: tower::Service<http::Request<BIn>, Response = http::Response<BOut>> + Clone + Send + 'static,
     S::Future: Send + 'static,
-    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    S::Error: Into<BoxError>,
     BIn: From<hyper::body::Incoming>,
     BOut: http_body::Body + Send + 'static,
-    BOut::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    BOut::Error: Into<BoxError>,
     IO: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     fn graceful_shutdown(self: Pin<&mut Self>) {
@@ -75,10 +76,10 @@ impl<S, IO, BIn, BOut> Protocol<S, IO, BIn> for http1::Builder
 where
     S: tower::Service<http::Request<BIn>, Response = http::Response<BOut>> + Clone + Send + 'static,
     S::Future: Send + 'static,
-    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    S::Error: Into<BoxError>,
     BIn: From<hyper::body::Incoming> + Send + 'static,
     BOut: http_body::Body + Send + 'static,
-    BOut::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    BOut::Error: Into<BoxError>,
     BOut::Data: Send,
     IO: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
@@ -103,11 +104,11 @@ impl<S, IO, BIn, BOut> Connection
 where
     S: tower::Service<http::Request<BIn>, Response = http::Response<BOut>> + Clone + Send + 'static,
     S::Future: Send + 'static,
-    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    S::Error: Into<BoxError>,
     BIn: From<hyper::body::Incoming> + 'static,
     BOut: http_body::Body + Send + 'static,
     BOut::Data: Send + 'static,
-    BOut::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    BOut::Error: Into<BoxError>,
     IO: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     fn graceful_shutdown(self: Pin<&mut Self>) {
@@ -119,10 +120,10 @@ impl<S, IO, BIn, BOut> Protocol<S, IO, BIn> for http2::Builder<TokioExecutor>
 where
     S: tower::Service<http::Request<BIn>, Response = http::Response<BOut>> + Clone + Send + 'static,
     S::Future: Send + 'static,
-    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    S::Error: Into<BoxError>,
     BIn: From<hyper::body::Incoming> + Send + 'static,
     BOut: http_body::Body + Send + 'static,
-    BOut::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    BOut::Error: Into<BoxError>,
     BOut::Data: Send + 'static,
     IO: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {

--- a/src/server/conn/stream.rs
+++ b/src/server/conn/stream.rs
@@ -14,6 +14,7 @@ use crate::info::HasConnectionInfo;
 use crate::stream::duplex::DuplexStream;
 #[cfg(feature = "stream")]
 use crate::stream::Braid;
+use crate::BoxError;
 use pin_project::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite};
 
@@ -36,7 +37,7 @@ pub trait Accept {
     type Conn: HasConnectionInfo + AsyncRead + AsyncWrite + Send + Unpin + 'static;
 
     /// The error type for this acceptor
-    type Error: Into<Box<dyn std::error::Error + Send + Sync>>;
+    type Error: Into<BoxError>;
 
     /// Poll for a new connection
     fn poll_accept(

--- a/src/server/conn/tls/info.rs
+++ b/src/server/conn/tls/info.rs
@@ -4,7 +4,7 @@
 
 use std::{fmt, task::Poll};
 
-use futures_core::future::BoxFuture;
+use crate::BoxFuture;
 use hyper::{Request, Response};
 use tower::{Layer, Service};
 use tracing::Instrument;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -63,12 +63,10 @@ use self::conn::Connection;
 use crate::bridge::rt::TokioExecutor;
 use crate::info::HasConnectionInfo;
 use crate::service::MakeServiceRef;
+use crate::{BoxError, BoxFuture};
 
 mod builder;
 pub mod conn;
-
-type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
-type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 /// A transport protocol for serving connections.
 ///
@@ -79,7 +77,7 @@ pub trait Protocol<S, IO, B> {
     type ResponseBody: Body + Send + 'static;
 
     /// The error when a connection has a problem.
-    type Error: Into<Box<dyn std::error::Error + Send + Sync>>;
+    type Error: Into<BoxError>;
 
     /// The connection future, used to drive a connection IO to completion.
     type Connection: Connection + Future<Output = Result<(), Self::Error>> + Send + 'static;

--- a/src/service/client.rs
+++ b/src/service/client.rs
@@ -8,7 +8,7 @@
 use std::fmt;
 use std::task::Poll;
 
-use futures_util::future::BoxFuture;
+use crate::BoxFuture;
 use http_body::Body;
 use tracing::Instrument;
 

--- a/src/service/http.rs
+++ b/src/service/http.rs
@@ -1,9 +1,10 @@
-use std::error::Error as StdError;
 use std::future::Future;
 use std::task::{Context, Poll};
 
 use http::{Request, Response};
 use http_body::Body as HttpBody;
+
+use crate::BoxError;
 
 /// An asynchronous function from `Request` to `Response`.
 pub trait HttpService<ReqBody> {
@@ -15,7 +16,7 @@ pub trait HttpService<ReqBody> {
     /// Note: Returning an `Error` to a hyper server will cause the connection
     /// to be abruptly aborted. In most cases, it is better to return a `Response`
     /// with a 4xx or 5xx status code.
-    type Error: Into<Box<dyn StdError + Send + Sync>>;
+    type Error: Into<BoxError>;
 
     /// The `Future` returned by this `Service`.
     type Future: Future<Output = Result<Response<Self::ResBody>, Self::Error>>;
@@ -31,7 +32,7 @@ impl<T, BIn, BOut> HttpService<BIn> for T
 where
     T: tower::Service<Request<BIn>, Response = Response<BOut>>,
     BOut: HttpBody,
-    T::Error: Into<Box<dyn StdError + Send + Sync>>,
+    T::Error: Into<BoxError>,
 {
     type ResBody = BOut;
 

--- a/src/service/shared.rs
+++ b/src/service/shared.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use futures_core::future::BoxFuture;
+use crate::BoxFuture;
 use tower::{Service, ServiceExt};
 
 /// A [`Service`] that can be cloned, sent, and shared across threads.


### PR DESCRIPTION
Unifying the implementations improves consistency.