### PR TITLE
feat(rt): Support executor generic servers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,12 @@ name = "h2-server"
 path = "examples/server/h2.rs"
 required-features = ["server", "tls", "tls-ring"]
 
+[[example]]
+name = "single-threaded"
+path = "examples/single_threaded.rs"
+required-features = ["server", "client"]
+
+
 [[test]]
 name = "stream-duplex"
 path = "tests/stream/duplex.rs"

--- a/examples/server/h2.rs
+++ b/examples/server/h2.rs
@@ -65,7 +65,8 @@ async fn main() {
         .with_shared_service(svc)
         .with_connection_info()
         .with_tls_connection_info()
-        .with_http2();
+        .with_http2()
+        .with_tokio();
 
     let (tx, rx) = tokio::sync::oneshot::channel();
 

--- a/examples/single_threaded.rs
+++ b/examples/single_threaded.rs
@@ -1,0 +1,459 @@
+//! This example closely follows the parent example from the `hyper` repository,
+//! to demonstrate using a single-threaded runtime.
+//!
+
+use std::cell::Cell;
+use std::future::Future;
+use std::marker::PhantomData;
+use std::net::SocketAddr;
+use std::pin::{pin, Pin};
+use std::rc::Rc;
+use std::task::{ready, Context, Poll};
+use std::thread;
+
+use futures_util::FutureExt;
+use http_body_util::BodyExt;
+use hyper::body::{Body as HttpBody, Bytes, Frame, Incoming};
+use hyper::Request;
+use hyper::{Error, Response};
+use hyperdriver::bridge::io::TokioIo;
+use hyperdriver::bridge::service::TowerHyperService;
+use hyperdriver::client::conn::connection::HttpConnection;
+use hyperdriver::client::conn::protocol::auto;
+use hyperdriver::client::conn::transport::tcp::{TcpConnectionError, TcpTransport};
+use hyperdriver::client::conn::transport::TransportExt;
+use hyperdriver::client::conn::Transport;
+use hyperdriver::client::ConnectionPoolLayer;
+use hyperdriver::info::HasConnectionInfo;
+use hyperdriver::server::Accept;
+use hyperdriver::service::{make_service_fn, RequestExecutor};
+use hyperdriver::stream::TcpStream;
+use pin_project::pin_project;
+use tokio::io::{self, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tower::service_fn;
+
+struct Body {
+    // Our Body type is !Send and !Sync:
+    // _marker: PhantomData<*const ()>,
+    _marker: PhantomData<()>,
+    data: Option<Bytes>,
+}
+
+impl From<String> for Body {
+    fn from(a: String) -> Self {
+        Body {
+            _marker: PhantomData,
+            data: Some(a.into()),
+        }
+    }
+}
+
+impl HttpBody for Body {
+    type Data = Bytes;
+    type Error = Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        Poll::Ready(self.get_mut().data.take().map(|d| Ok(Frame::data(d))))
+    }
+}
+
+fn main() {
+    // pretty_env_logger::init();
+
+    let (tx, rx) = oneshot::channel::<()>();
+    let server_http2 = thread::spawn(move || {
+        // Configure a runtime for the server that runs everything on the current thread
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build runtime");
+
+        // Combine it with a `LocalSet,  which means it can spawn !Send futures...
+        let local = tokio::task::LocalSet::new();
+        local.block_on(&rt, http2_server(rx)).unwrap();
+    });
+
+    let client_http2 = thread::spawn(move || {
+        // Configure a runtime for the client that runs everything on the current thread
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build runtime");
+
+        // Combine it with a `LocalSet,  which means it can spawn !Send futures...
+        let local = tokio::task::LocalSet::new();
+        local
+            .block_on(
+                &rt,
+                http2_client("http://localhost:3000".parse::<hyper::Uri>().unwrap(), tx),
+            )
+            .unwrap();
+    });
+
+    let (tx, rx) = oneshot::channel::<()>();
+
+    let server_http1 = thread::spawn(move || {
+        // Configure a runtime for the server that runs everything on the current thread
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build runtime");
+
+        // Combine it with a `LocalSet,  which means it can spawn !Send futures...
+        let local = tokio::task::LocalSet::new();
+        local.block_on(&rt, http1_server(rx)).unwrap();
+    });
+
+    let client_http1 = thread::spawn(move || {
+        // Configure a runtime for the client that runs everything on the current thread
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build runtime");
+
+        // Combine it with a `LocalSet,  which means it can spawn !Send futures...
+        let local = tokio::task::LocalSet::new();
+        local
+            .block_on(
+                &rt,
+                http1_client("http://localhost:3001".parse::<hyper::Uri>().unwrap(), tx),
+            )
+            .unwrap();
+    });
+
+    server_http2.join().unwrap();
+    client_http2.join().unwrap();
+
+    server_http1.join().unwrap();
+    client_http1.join().unwrap();
+}
+
+async fn http1_server(rx: oneshot::Receiver<()>) -> Result<(), Box<dyn std::error::Error>> {
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3001));
+
+    let listener = TcpListener::bind(addr).await?;
+
+    // For each connection, clone the counter to use in our service...
+    let counter = Rc::new(Cell::new(0));
+
+    let mut rx = pin!(rx);
+
+    loop {
+        let (stream, addr) = tokio::select! {
+            _ = &mut rx => return Ok(()),
+            res = listener.accept() => res?,
+        };
+
+        let io = IOTypeNotSend::new(TcpStream::server(stream, addr));
+
+        let cnt = counter.clone();
+
+        let service = service_fn(move |_| {
+            let prev = cnt.get();
+            cnt.set(prev + 1);
+            let value = cnt.get();
+            async move {
+                Ok::<_, Error>(Response::new(Body::from(format!(
+                    "HTTP/1.1 Request #{}",
+                    value
+                ))))
+            }
+        });
+
+        tokio::task::spawn_local(async move {
+            if let Err(err) = hyper::server::conn::http1::Builder::new()
+                .serve_connection(TokioIo::new(io), TowerHyperService::new(service))
+                .await
+            {
+                println!("Error serving connection: {:?}", err);
+            }
+        });
+    }
+}
+
+async fn http1_client(
+    url: hyper::Uri,
+    tx: oneshot::Sender<()>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let host = url.host().expect("uri has no host");
+    let port = url.port_u16().unwrap_or(80);
+    let addr = format!("{}:{}", host, port);
+    let stream = TcpStream::connect(addr).await?;
+
+    let io = TokioIo::new(IOTypeNotSend::new(stream));
+
+    let (mut sender, conn) = hyper::client::conn::http1::handshake(io).await?;
+
+    tokio::task::spawn_local(async move {
+        if let Err(err) = conn.await {
+            let mut stdout = io::stdout();
+            stdout
+                .write_all(format!("Connection failed: {:?}", err).as_bytes())
+                .await
+                .unwrap();
+            stdout.flush().await.unwrap();
+        }
+    });
+
+    let authority = url.authority().unwrap().clone();
+
+    // Make 4 requests
+    for _ in 0..4 {
+        let req = Request::builder()
+            .uri(url.clone())
+            .header(hyper::header::HOST, authority.as_str())
+            .body(Body::from("test".to_string()))?;
+
+        let mut res = sender.send_request(req).await?;
+
+        let mut stdout = io::stdout();
+        stdout
+            .write_all(format!("Response: {}\n", res.status()).as_bytes())
+            .await
+            .unwrap();
+        stdout
+            .write_all(format!("Headers: {:#?}\n", res.headers()).as_bytes())
+            .await
+            .unwrap();
+        stdout.flush().await.unwrap();
+
+        // Print the response body
+        while let Some(next) = res.frame().await {
+            let frame = next?;
+            if let Some(chunk) = frame.data_ref() {
+                stdout.write_all(chunk).await.unwrap();
+            }
+        }
+        stdout.write_all(b"\n-----------------\n").await.unwrap();
+        stdout.flush().await.unwrap();
+    }
+
+    let _ = tx.send(());
+
+    Ok(())
+}
+
+async fn http2_server(rx: oneshot::Receiver<()>) -> Result<(), Box<dyn std::error::Error>> {
+    use hyper::server::conn::http2;
+
+    let mut stdout = io::stdout();
+
+    let addr: SocketAddr = ([127, 0, 0, 1], 3000).into();
+    // Using a !Send request counter is fine on 1 thread...
+    let counter = Rc::new(Cell::new(0));
+
+    let listener = TcpListener::bind(addr).await?;
+
+    stdout
+        .write_all(format!("Listening on http://{}", addr).as_bytes())
+        .await
+        .unwrap();
+    stdout.flush().await.unwrap();
+
+    let server = hyperdriver::Server::builder()
+        .with_acceptor(AcceptNotSend::new(listener))
+        .with_protocol(http2::Builder::new(LocalExec))
+        .with_make_service(make_service_fn(|_| {
+            let counter = counter.clone();
+            async move {
+                Ok::<_, Error>(service_fn(move |_: http::Request<Incoming>| {
+                    let prev = counter.get();
+                    counter.set(prev + 1);
+                    let value = counter.get();
+                    async move {
+                        Ok::<_, Error>(Response::new(Body::from(format!(
+                            "HTTP/2 Request #{}",
+                            value
+                        ))))
+                    }
+                }))
+            }
+        }))
+        .with_executor(LocalExec);
+
+    // static_assertions::assert_impl_one!(http2::Builder<LocalExec>: hyperdriver::server::Protocol<SharedService<http::Request<hyper::body::Incoming>, http::Response<Body>, io::Error>, IOTypeNotSend, hyper::body::Incoming>);
+    // static_assertions::assert_impl_one!(LocalExec: ServerExecutor<http2::Builder<LocalExec>, BoxMakeServiceRef<IOTypeNotSend, SharedService<http::Request<Body>, http::Response<Body>, io::Error>, io::Error>, AcceptNotSend, Body>);
+
+    server
+        .with_graceful_shutdown(async {
+            let _ = rx.await;
+        })
+        .await?;
+
+    Ok(())
+}
+
+async fn http2_client(
+    url: hyper::Uri,
+    tx: oneshot::Sender<()>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let client = tower::ServiceBuilder::new()
+        .layer(
+            ConnectionPoolLayer::new(
+                TcpTransport::<_, TcpStream>::default().without_tls(),
+                auto::HttpConnectionBuilder::<Body>::default(),
+            )
+            .with_optional_pool(Some(Default::default())),
+        )
+        .service(RequestExecutor::<HttpConnection<Body>, _>::new());
+
+    let authority = url.authority().unwrap().clone();
+
+    // Make 4 requests
+    for _ in 0..4 {
+        let req = Request::builder()
+            .uri(url.clone())
+            .version(http::Version::HTTP_2)
+            .header(http::header::HOST, authority.as_str())
+            .body(Body::from("test".to_string()))?;
+
+        let mut res = client.request(req).await?;
+
+        let mut stdout = io::stdout();
+        stdout
+            .write_all(format!("Response: {}\n", res.status()).as_bytes())
+            .await
+            .unwrap();
+        stdout
+            .write_all(format!("Headers: {:#?}\n", res.headers()).as_bytes())
+            .await
+            .unwrap();
+        stdout.flush().await.unwrap();
+
+        // Print the response body
+        while let Some(next) = res.frame().await {
+            let frame = next?;
+            if let Some(chunk) = frame.data_ref() {
+                stdout.write_all(chunk).await.unwrap();
+            }
+        }
+        stdout.write_all(b"\n-----------------\n").await.unwrap();
+        stdout.flush().await.unwrap();
+    }
+
+    let _ = tx.send(());
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug)]
+struct LocalExec;
+
+impl<F> hyper::rt::Executor<F> for LocalExec
+where
+    F: std::future::Future + 'static, // not requiring `Send`
+    F::Output: 'static,
+{
+    fn execute(&self, fut: F) {
+        // This will spawn into the currently running `LocalSet`.
+        tokio::task::spawn_local(fut);
+    }
+}
+
+#[derive(Debug)]
+#[pin_project]
+struct AcceptNotSend(#[pin] TcpListener);
+
+impl AcceptNotSend {
+    fn new(listener: TcpListener) -> Self {
+        Self(listener)
+    }
+}
+
+impl Accept for AcceptNotSend {
+    type Conn = IOTypeNotSend;
+
+    type Error = std::io::Error;
+
+    fn poll_accept(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Self::Conn, Self::Error>> {
+        let stream = ready!(self.project().0.poll_accept(cx)).map(IOTypeNotSend::new);
+        Poll::Ready(stream)
+    }
+}
+
+#[derive(Clone)]
+struct TransportNotSend {
+    tcp: TcpTransport,
+}
+
+impl Transport for TransportNotSend {
+    type IO = TcpStream;
+
+    type Error = TcpConnectionError;
+
+    type Future = Pin<Box<dyn Future<Output = Result<Self::IO, Self::Error>> + Send>>;
+
+    fn connect(&mut self, uri: http::Uri) -> <Self as Transport>::Future {
+        self.tcp.connect(uri).boxed()
+    }
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), <Self as Transport>::Error>> {
+        self.tcp.poll_ready(cx)
+    }
+}
+
+struct IOTypeNotSend {
+    _marker: PhantomData<*const ()>,
+    stream: TcpStream,
+}
+
+impl IOTypeNotSend {
+    fn new(stream: TcpStream) -> Self {
+        Self {
+            _marker: PhantomData,
+            stream,
+        }
+    }
+}
+
+impl HasConnectionInfo for IOTypeNotSend {
+    type Addr = <TcpStream as HasConnectionInfo>::Addr;
+
+    fn info(&self) -> hyperdriver::info::ConnectionInfo<Self::Addr> {
+        self.stream.info()
+    }
+}
+
+impl tokio::io::AsyncWrite for IOTypeNotSend {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        Pin::new(&mut self.stream).poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        Pin::new(&mut self.stream).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        Pin::new(&mut self.stream).poll_shutdown(cx)
+    }
+}
+
+impl tokio::io::AsyncRead for IOTypeNotSend {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.stream).poll_read(cx, buf)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ pub(crate) fn polled_span(span: &tracing::Span) {
 pub(crate) mod private {
 
     #[allow(unused)]
-    pub trait Sealed {}
+    pub trait Sealed<T> {}
 }
 
 /// Test fixtures for the `hyperdriver` crate.

--- a/src/server/conn/connecting.rs
+++ b/src/server/conn/connecting.rs
@@ -1,9 +1,14 @@
+#![allow(clippy::type_complexity)]
+
 use std::future::Future;
 use std::pin::Pin;
 use std::task::ready;
 use std::task::Poll;
 
 use http;
+use hyper::body::Incoming;
+use hyper::rt::bounds::Http2ServerConnExec;
+use hyper::service::HttpService;
 use ouroboros::self_referencing;
 use tokio::io::AsyncRead;
 use tokio::io::AsyncWrite;
@@ -13,36 +18,38 @@ use super::auto::UpgradableConnection;
 use super::ConnectionError;
 use crate::body::IncomingRequestService;
 use crate::bridge::io::TokioIo;
-use crate::bridge::rt::TokioExecutor;
 use crate::bridge::service::TowerHyperService;
 use crate::BoxError;
 
-type Connection<'a, S, IO, BIn, BOut> = UpgradableConnection<
+type Connection<'a, S, IO, BIn, BOut, E> = UpgradableConnection<
     'a,
     TokioIo<IO>,
     TowerHyperService<IncomingRequestService<S, BIn, BOut>>,
-    TokioExecutor,
+    E,
 >;
+
+type Adapt<S, BIn, BOut> = TowerHyperService<IncomingRequestService<S, BIn, BOut>>;
 
 /// Connection that handles the self-referential relationship between
 /// the protocol and the connection.
 #[self_referencing]
-pub struct Connecting<S, IO, BIn, BOut>
+pub struct Connecting<S, IO, BIn, BOut, E>
 where
     S: tower::Service<http::Request<BIn>, Response = http::Response<BOut>> + Clone + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<BoxError>,
     BIn: From<hyper::body::Incoming>,
     BOut: http_body::Body,
+    E: 'static,
 {
-    protocol: Builder<TokioExecutor>,
+    protocol: Builder<E>,
 
     #[borrows(protocol)]
     #[not_covariant]
-    conn: Pin<Box<Connection<'this, S, IO, BIn, BOut>>>,
+    conn: Pin<Box<Connection<'this, S, IO, BIn, BOut, E>>>,
 }
 
-impl<S, IO, BIn, BOut> Connecting<S, IO, BIn, BOut>
+impl<S, IO, BIn, BOut, E> Connecting<S, IO, BIn, BOut, E>
 where
     S: tower::Service<http::Request<BIn>, Response = http::Response<BOut>> + Clone + Send + 'static,
     S::Future: Send + 'static,
@@ -51,7 +58,7 @@ where
     BOut: http_body::Body + 'static,
     IO: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
-    pub(crate) fn build(protocol: Builder<TokioExecutor>, service: S, stream: IO) -> Self {
+    pub(crate) fn build(protocol: Builder<E>, service: S, stream: IO) -> Self {
         Self::new(protocol, move |protocol| {
             Box::pin(protocol.serve_connection_with_upgrades(
                 TokioIo::new(stream),
@@ -61,32 +68,34 @@ where
     }
 }
 
-impl<S, IO, BIn, BOut> crate::server::Connection for Connecting<S, IO, BIn, BOut>
+impl<S, IO, BIn, BOut, E> crate::server::Connection for Connecting<S, IO, BIn, BOut, E>
 where
     S: tower::Service<http::Request<BIn>, Response = http::Response<BOut>> + Clone + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<BoxError>,
-    BIn: From<hyper::body::Incoming> + 'static,
+    BIn: http_body::Body + From<hyper::body::Incoming> + 'static,
     BOut: http_body::Body + Send + 'static,
     BOut::Data: Send + 'static,
     BOut::Error: Into<BoxError>,
     IO: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+    E: Http2ServerConnExec<<Adapt<S, BIn, BOut> as HttpService<Incoming>>::Future, BOut>,
 {
     fn graceful_shutdown(mut self: Pin<&mut Self>) {
         self.with_conn_mut(|conn| conn.as_mut().graceful_shutdown())
     }
 }
 
-impl<S, IO, BIn, BOut> Future for Connecting<S, IO, BIn, BOut>
+impl<S, IO, BIn, BOut, E> Future for Connecting<S, IO, BIn, BOut, E>
 where
     S: tower::Service<http::Request<BIn>, Response = http::Response<BOut>> + Clone + Send + 'static,
     S::Future: Send + 'static,
     S::Error: Into<BoxError>,
-    BIn: From<hyper::body::Incoming> + 'static,
+    BIn: http_body::Body + From<hyper::body::Incoming> + 'static,
     BOut: http_body::Body + Send + 'static,
     BOut::Data: Send + 'static,
     BOut::Error: Into<BoxError>,
     IO: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+    E: Http2ServerConnExec<<Adapt<S, BIn, BOut> as HttpService<Incoming>>::Future, BOut>,
 {
     type Output = Result<(), ConnectionError>;
 
@@ -94,7 +103,7 @@ where
         mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Self::Output> {
-        match ready!(self.with_conn_mut(|conn| Pin::new(conn).poll(cx))) {
+        match ready!(self.with_conn_mut(|conn| conn.as_mut().poll(cx))) {
             Ok(()) => Poll::Ready(Ok(())),
             Err(e) => Poll::Ready(Err(e)),
         }

--- a/src/server/conn/drivers.rs
+++ b/src/server/conn/drivers.rs
@@ -1,0 +1,206 @@
+use std::fmt;
+use std::future::{Future, IntoFuture as _};
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_util::future::{Fuse, FutureExt as _};
+use hyper::rt::Executor;
+use pin_project::pin_project;
+use tracing::debug;
+use tracing::instrument::Instrumented;
+use tracing::Span;
+
+use crate::private::Sealed;
+use crate::server::{Accept, Connection, MakeServiceRef, Protocol};
+use crate::server::{CloseFuture, CloseReciever, CloseSender};
+
+/// An executor suitable for spawning connection futures
+/// and driving them to completion.
+pub trait ServerExecutor<P, S, A, B>:
+    Executor<
+        ConnectionDriver<
+            Instrumented<P::Connection>,
+            <P as Protocol<S::Service, A::Conn, B>>::Error,
+        >,
+    > + Sealed<(P, S, A, B)>
+where
+    P: Protocol<S::Service, A::Conn, B>,
+    S: MakeServiceRef<A::Conn, B>,
+    A: Accept,
+{
+}
+
+impl<P, S, A, B, E> ServerExecutor<P, S, A, B> for E
+where
+    P: Protocol<S::Service, A::Conn, B>,
+    S: MakeServiceRef<A::Conn, B>,
+    A: Accept,
+    E: Executor<
+        ConnectionDriver<
+            Instrumented<P::Connection>,
+            <P as Protocol<S::Service, A::Conn, B>>::Error,
+        >,
+    >,
+{
+}
+
+impl<P, S, A, B, E> Sealed<(P, S, A, B)> for E {}
+
+/// Internal struct to manage driving a connection
+/// to completion.
+///
+/// Only used in the bounds for ServerExecutor.
+#[derive(Debug)]
+#[pin_project]
+pub struct ConnectionDriver<C, E> {
+    #[pin]
+    conn: C,
+    _phantom: PhantomData<fn() -> E>,
+}
+
+impl<C, E> ConnectionDriver<C, E> {
+    pub(in crate::server) fn new(conn: C) -> Self {
+        ConnectionDriver {
+            conn,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<C, E> Future for ConnectionDriver<C, E>
+where
+    C: Future<Output = Result<(), E>>,
+    E: fmt::Debug,
+{
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        match this.conn.poll(cx) {
+            Poll::Ready(Ok(())) => Poll::Ready(()),
+            Poll::Ready(Err(e)) => {
+                debug!("connection error: {:?}", e);
+                Poll::Ready(())
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// An executor suitable for spawning connection futures
+/// and driving them to completion.
+pub trait GracefulServerExecutor<P, S, A, B>:
+    Executor<
+        GracefulConnectionDriver<
+            Instrumented<P::Connection>,
+            <P as Protocol<S::Service, A::Conn, B>>::Error,
+        >,
+    > + ServerExecutor<P, S, A, B>
+    + Sealed<(P, S, A, B, ())>
+where
+    P: Protocol<S::Service, A::Conn, B>,
+    S: MakeServiceRef<A::Conn, B>,
+    A: Accept,
+{
+}
+
+impl<P, S, A, B, E> GracefulServerExecutor<P, S, A, B> for E
+where
+    P: Protocol<S::Service, A::Conn, B>,
+    S: MakeServiceRef<A::Conn, B>,
+    A: Accept,
+    E: ServerExecutor<P, S, A, B>
+        + Executor<
+            GracefulConnectionDriver<
+                Instrumented<P::Connection>,
+                <P as Protocol<S::Service, A::Conn, B>>::Error,
+            >,
+        > + Sealed<(P, S, A, B, ())>,
+{
+}
+
+impl<P, S, A, B, E> Sealed<(P, S, A, B, ())> for E
+where
+    P: Protocol<S::Service, A::Conn, B>,
+    S: MakeServiceRef<A::Conn, B>,
+    A: Accept,
+    E: Executor<
+        GracefulConnectionDriver<
+            Instrumented<P::Connection>,
+            <P as Protocol<S::Service, A::Conn, B>>::Error,
+        >,
+    >,
+{
+}
+
+/// Internal struct to manage driving a connection to completion while
+/// handling graceful shutdown.
+#[pin_project]
+pub struct GracefulConnectionDriver<C, E> {
+    #[pin]
+    conn: ConnectionDriver<C, E>,
+    #[pin]
+    shutdown: Fuse<CloseFuture>,
+    finished: CloseSender,
+    span: Span,
+}
+
+impl<C, E> fmt::Debug for GracefulConnectionDriver<C, E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GracefulConnectionDriver").finish()
+    }
+}
+
+impl<C, E> GracefulConnectionDriver<C, E> {
+    pub(in crate::server) fn new(
+        conn: C,
+        shutdown: CloseReciever,
+        finished: CloseSender,
+        span: Span,
+    ) -> Self {
+        Self {
+            conn: ConnectionDriver::new(conn),
+            shutdown: shutdown.into_future().fuse(),
+            finished,
+            span,
+        }
+    }
+}
+
+impl<C, E> Future for GracefulConnectionDriver<Instrumented<C>, E>
+where
+    C: Connection + Future<Output = Result<(), E>>,
+    E: fmt::Debug,
+{
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+
+        let _guard = this.span.enter();
+
+        loop {
+            match this.conn.as_mut().poll(cx) {
+                Poll::Ready(()) => {
+                    this.finished.send();
+                    return Poll::Ready(());
+                }
+                Poll::Pending => {}
+            };
+
+            match this.shutdown.as_mut().poll(cx) {
+                Poll::Ready(()) => {
+                    debug!("connection received shutdown signal");
+                    this.conn
+                        .as_mut()
+                        .project()
+                        .conn
+                        .inner_pin_mut()
+                        .graceful_shutdown();
+                }
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}

--- a/src/server/conn/stream.rs
+++ b/src/server/conn/stream.rs
@@ -34,7 +34,7 @@ use crate::stream::tls::TlsHandshakeStream;
 /// An async generator of new connections
 pub trait Accept {
     /// The connection type for this acceptor
-    type Conn: HasConnectionInfo + AsyncRead + AsyncWrite + Send + Unpin + 'static;
+    type Conn: HasConnectionInfo + AsyncRead + AsyncWrite + Unpin + 'static;
 
     /// The error type for this acceptor
     type Error: Into<BoxError>;

--- a/src/service/incoming.rs
+++ b/src/service/incoming.rs
@@ -197,7 +197,7 @@ where
 {
     type Response = http::Response<BOut>;
     type Error = T::Error;
-    type Future = future::AdaptIncomingFuture<T::Future, BOut, T::Error>;
+    type Future = future::IncomingResponseFuture<T::Future, BOut, T::Error>;
 
     fn poll_ready(
         &mut self,
@@ -207,7 +207,7 @@ where
     }
 
     fn call(&mut self, req: http::Request<BIn>) -> Self::Future {
-        future::AdaptIncomingFuture::new(self.inner.call(req))
+        future::IncomingResponseFuture::new(self.inner.call(req))
     }
 }
 
@@ -218,13 +218,13 @@ mod future {
 
     #[derive(Debug)]
     #[pin_project::pin_project]
-    pub struct AdaptIncomingFuture<F, BOut, Error> {
+    pub struct IncomingResponseFuture<F, BOut, Error> {
         #[pin]
         future: F,
         body: std::marker::PhantomData<fn() -> (BOut, Error)>,
     }
 
-    impl<F, BOut, Error> AdaptIncomingFuture<F, BOut, Error> {
+    impl<F, BOut, Error> IncomingResponseFuture<F, BOut, Error> {
         pub fn new(future: F) -> Self {
             Self {
                 future,
@@ -233,7 +233,7 @@ mod future {
         }
     }
 
-    impl<F, BOut, Error> Future for AdaptIncomingFuture<F, BOut, Error>
+    impl<F, BOut, Error> Future for IncomingResponseFuture<F, BOut, Error>
     where
         F: Future<Output = Result<http::Response<hyper::body::Incoming>, Error>>,
         BOut: From<hyper::body::Incoming>,

--- a/src/stream/tls.rs
+++ b/src/stream/tls.rs
@@ -2,7 +2,6 @@
 //! and so involve a negotiation component.
 
 use std::{
-    future::poll_fn,
     io,
     pin::Pin,
     task::{Context, Poll},
@@ -12,12 +11,37 @@ use std::{
 use crate::info::tls::TlsConnectionInfoReciever;
 pub use crate::info::TlsConnectionInfo;
 use futures_core::Future;
-use futures_util::FutureExt;
 use pin_project::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite};
 
+/// Future returned by `TlsHandshakeStream::finish_handshake`.
+///
+/// This future resolves when the handshake is complete.
+#[pin_project]
+#[derive(Debug)]
+pub struct Handshaking<'a, T: ?Sized> {
+    inner: &'a mut T,
+}
+
+impl<'a, T: ?Sized> Handshaking<'a, T> {
+    fn new(inner: &'a mut T) -> Self {
+        Handshaking { inner }
+    }
+}
+
+impl<'a, T> Future for Handshaking<'a, T>
+where
+    T: TlsHandshakeStream + ?Sized,
+{
+    type Output = Result<(), io::Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().inner.poll_handshake(cx)
+    }
+}
+
 /// A stream that supports a TLS handshake.
-pub trait TlsHandshakeStream: Send {
+pub trait TlsHandshakeStream {
     /// Poll the handshake to completion.
     fn poll_handshake(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>>;
 
@@ -26,10 +50,8 @@ pub trait TlsHandshakeStream: Send {
     /// This method will drive the connection asynchronosly allowing you to wait
     /// for the TLS handshake to complete. If this method is not called, the TLS handshake
     /// will be completed the first time the connection is used.
-    fn finish_handshake(
-        &mut self,
-    ) -> Pin<Box<dyn Future<Output = Result<(), io::Error>> + Send + '_>> {
-        poll_fn(|cx| self.poll_handshake(cx)).boxed()
+    fn finish_handshake(&mut self) -> Handshaking<'_, Self> {
+        Handshaking::new(self)
     }
 }
 
@@ -53,7 +75,7 @@ pub enum TlsBraid<Tls, NoTls> {
 impl<Tls, NoTls> TlsHandshakeStream for TlsBraid<Tls, NoTls>
 where
     Tls: TlsHandshakeStream + Unpin,
-    NoTls: AsyncRead + AsyncWrite + Send + Unpin,
+    NoTls: AsyncRead + AsyncWrite + Unpin,
 {
     fn poll_handshake(
         &mut self,
@@ -83,7 +105,7 @@ where
 #[cfg(feature = "client")]
 impl<Tls, NoTls> crate::client::pool::PoolableStream for TlsBraid<Tls, NoTls>
 where
-    Tls: TlsHandshakeStream + Unpin + 'static,
+    Tls: TlsHandshakeStream + Send + Unpin + 'static,
     NoTls: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     fn can_share(&self) -> bool {

--- a/tests/server/custombody.rs
+++ b/tests/server/custombody.rs
@@ -83,7 +83,8 @@ async fn custom_body_server() {
         .with_acceptor(incoming)
         .with_auto_http()
         .with_shared_service(service)
-        .with_connection_info();
+        .with_connection_info()
+        .with_tokio();
 
     let (tx, rx) = tokio::sync::oneshot::channel();
 

--- a/tests/server/graceful.rs
+++ b/tests/server/graceful.rs
@@ -40,7 +40,8 @@ async fn before_request() {
     let server = Server::builder()
         .with_acceptor(acceptor)
         .with_shared_service(tower::service_fn(echo))
-        .with_auto_http();
+        .with_auto_http()
+        .with_tokio();
 
     let serve = server.with_graceful_shutdown(async {
         if rx.await.is_err() {


### PR DESCRIPTION
Adds an additional generic parameter to allow for providing an executor. Although this appears to complicate trait bounds, mostly, any implementation of hyper::rt::Executor should work.