### PR TITLE
feat: Make connection pool generic over the key type

### DIFF
--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -18,7 +18,7 @@ use super::conn::transport::TransportExt;
 use super::conn::Connection;
 use super::conn::Protocol;
 use super::conn::Transport;
-use super::pool::{PoolableConnection, PoolableStream};
+use super::pool::{self, PoolableConnection, PoolableStream};
 use super::ConnectionPoolLayer;
 use crate::service::RequestExecutor;
 use crate::service::{Http1ChecksLayer, Http2ChecksLayer, SetHostHeaderLayer};
@@ -463,7 +463,7 @@ where
                     .with_optional_pool(self.pool.clone()),
             )
             .layer(SetHostHeaderLayer::new())
-            .layer(Http2ChecksLayer::new())
+            .layer(Http2ChecksLayer::<_, _, pool::UriKey>::new())
             .layer(Http1ChecksLayer::new())
             .service(RequestExecutor::new());
 

--- a/src/client/conn/connection.rs
+++ b/src/client/conn/connection.rs
@@ -8,8 +8,8 @@ use http_body::Body as HttpBody;
 use hyper::body::Incoming;
 use thiserror::Error;
 
-pub use crate::client::pool::key::UriError;
 use crate::client::pool::PoolableConnection;
+pub use crate::client::pool::UriError;
 
 /// A connection to a remote server which can send and recieve HTTP requests/responses.
 ///

--- a/src/client/pool/key.rs
+++ b/src/client/pool/key.rs
@@ -1,27 +1,13 @@
 use std::{fmt, str::FromStr};
 
-use thiserror::Error;
+use super::UriError;
 
-/// The URI used for connecting to a server is invalid.
-///
-/// Usually, this means that the URI is missing a scheme or authority,
-/// but it can also mean that the connection string could not be parsed.
-#[derive(Debug, Error)]
-#[non_exhaustive]
-pub enum UriError {
-    /// The connection string could not be parsed.
-    #[error("invalid uri: {0}")]
-    InvalidUri(#[from] http::uri::InvalidUri),
-
-    /// The URI is missing a scheme.
-    #[error("missing scheme in uri: {0}")]
-    MissingScheme(http::Uri),
-}
-
+/// Pool key which is used to identify a connection - using scheme
+/// and authority.
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub(crate) struct Key(http::uri::Scheme, Option<http::uri::Authority>);
+pub struct UriKey(http::uri::Scheme, Option<http::uri::Authority>);
 
-impl fmt::Display for Key {
+impl fmt::Display for UriKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -32,13 +18,13 @@ impl fmt::Display for Key {
     }
 }
 
-impl From<(http::uri::Scheme, http::uri::Authority)> for Key {
+impl From<(http::uri::Scheme, http::uri::Authority)> for UriKey {
     fn from(value: (http::uri::Scheme, http::uri::Authority)) -> Self {
         Self(value.0, Some(value.1))
     }
 }
 
-impl TryFrom<http::Uri> for Key {
+impl TryFrom<http::Uri> for UriKey {
     type Error = UriError;
 
     fn try_from(value: http::Uri) -> Result<Self, Self::Error> {
@@ -53,7 +39,7 @@ impl TryFrom<http::Uri> for Key {
     }
 }
 
-impl FromStr for Key {
+impl FromStr for UriKey {
     type Err = UriError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -69,7 +55,7 @@ pub(crate) mod test_key {
     #[test]
     fn key_from_uri() {
         let uri = http::Uri::from_static("http://localhost:8080");
-        let key: Key = uri.try_into().unwrap();
+        let key: UriKey = uri.try_into().unwrap();
         assert_eq!(key.0, http::uri::Scheme::HTTP);
         assert_eq!(
             key.1,
@@ -79,7 +65,7 @@ pub(crate) mod test_key {
 
     #[test]
     fn key_display() {
-        let key = Key(
+        let key = UriKey(
             http::uri::Scheme::HTTP,
             Some(http::uri::Authority::from_static("localhost:8080")),
         );
@@ -88,7 +74,7 @@ pub(crate) mod test_key {
 
     #[test]
     fn key_from_tuple() {
-        let key: Key = (
+        let key: UriKey = (
             http::uri::Scheme::HTTP,
             http::uri::Authority::from_static("localhost:8080"),
         )
@@ -102,10 +88,13 @@ pub(crate) mod test_key {
 
     #[test]
     fn key_debug() {
-        let key = Key(
+        let key = UriKey(
             http::uri::Scheme::HTTP,
             Some(http::uri::Authority::from_static("localhost:8080")),
         );
-        assert_eq!(format!("{:?}", key), "Key(\"http\", Some(localhost:8080))");
+        assert_eq!(
+            format!("{:?}", key),
+            "UriKey(\"http\", Some(localhost:8080))"
+        );
     }
 }

--- a/src/service/host.rs
+++ b/src/service/host.rs
@@ -91,10 +91,11 @@ where
     }
 }
 
-impl<S, B, C> tower::Service<ExecuteRequest<C, B>> for SetHostHeader<S>
+impl<S, B, C, K> tower::Service<ExecuteRequest<C, B, K>> for SetHostHeader<S>
 where
-    S: tower::Service<ExecuteRequest<C, B>>,
+    S: tower::Service<ExecuteRequest<C, B, K>>,
     C: Connection<B> + PoolableConnection,
+    K: crate::client::pool::Key,
 {
     type Response = S::Response;
 
@@ -109,7 +110,7 @@ where
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, mut req: ExecuteRequest<C, B>) -> Self::Future {
+    fn call(&mut self, mut req: ExecuteRequest<C, B, K>) -> Self::Future {
         if req.connection().version() < http::Version::HTTP_2 {
             set_host_header(req.request_mut());
         }

--- a/src/service/http.rs
+++ b/src/service/http.rs
@@ -59,28 +59,31 @@ pub(super) mod http1 {
     use http::Uri;
 
     use crate::client::conn::Connection;
-    use crate::client::pool::PoolableConnection;
+    use crate::client::pool::{Key, PoolableConnection};
     use crate::client::Error;
     use crate::service::client::ExecuteRequest;
     use crate::service::error::MaybeErrorFuture;
     use crate::service::error::PreprocessService;
 
-    type PreprocessFn<C, B, E> = fn(ExecuteRequest<C, B>) -> Result<ExecuteRequest<C, B>, E>;
+    type PreprocessFn<C, B, K, E> =
+        fn(ExecuteRequest<C, B, K>) -> Result<ExecuteRequest<C, B, K>, E>;
 
     /// A service that checks if the request is HTTP/1.1 compatible.
     #[derive(Debug)]
-    pub struct Http1ChecksService<S, C, B>
+    pub struct Http1ChecksService<S, C, B, K>
     where
-        S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
+        S: tower::Service<ExecuteRequest<C, B, K>, Error = Error>,
         C: Connection<B> + PoolableConnection,
+        K: Key,
     {
-        inner: PreprocessService<S, PreprocessFn<C, B, S::Error>>,
+        inner: PreprocessService<S, PreprocessFn<C, B, K, S::Error>>,
     }
 
-    impl<S, C, B> tower::Service<ExecuteRequest<C, B>> for Http1ChecksService<S, C, B>
+    impl<S, C, B, K> tower::Service<ExecuteRequest<C, B, K>> for Http1ChecksService<S, C, B, K>
     where
-        S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
+        S: tower::Service<ExecuteRequest<C, B, K>, Error = Error>,
         C: Connection<B> + PoolableConnection,
+        K: Key,
     {
         type Response = S::Response;
 
@@ -92,15 +95,16 @@ pub(super) mod http1 {
             self.inner.poll_ready(cx)
         }
 
-        fn call(&mut self, req: ExecuteRequest<C, B>) -> Self::Future {
+        fn call(&mut self, req: ExecuteRequest<C, B, K>) -> Self::Future {
             self.inner.call(req)
         }
     }
 
-    impl<S, C, B> Clone for Http1ChecksService<S, C, B>
+    impl<S, C, B, K> Clone for Http1ChecksService<S, C, B, K>
     where
-        S: tower::Service<ExecuteRequest<C, B>, Error = Error> + Clone,
+        S: tower::Service<ExecuteRequest<C, B, K>, Error = Error> + Clone,
         C: Connection<B> + PoolableConnection,
+        K: Key,
     {
         fn clone(&self) -> Self {
             Self {
@@ -109,10 +113,11 @@ pub(super) mod http1 {
         }
     }
 
-    impl<S, C, B> Http1ChecksService<S, C, B>
+    impl<S, C, B, K> Http1ChecksService<S, C, B, K>
     where
-        S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
+        S: tower::Service<ExecuteRequest<C, B, K>, Error = Error>,
         C: Connection<B> + PoolableConnection,
+        K: Key,
     {
         /// Create a new `Http1ChecksService`.
         pub fn new(service: S) -> Self {
@@ -123,11 +128,11 @@ pub(super) mod http1 {
     }
 
     /// A layer that checks if the request is HTTP/1.1 compatible.
-    pub struct Http1ChecksLayer<C, B> {
-        processor: std::marker::PhantomData<fn(C, B)>,
+    pub struct Http1ChecksLayer<C, B, K> {
+        processor: std::marker::PhantomData<fn(C, B, K)>,
     }
 
-    impl<C, B> Http1ChecksLayer<C, B> {
+    impl<C, B, K> Http1ChecksLayer<C, B, K> {
         /// Create a new `Http1ChecksLayer`.
         pub fn new() -> Self {
             Self {
@@ -136,41 +141,43 @@ pub(super) mod http1 {
         }
     }
 
-    impl<C, B> Default for Http1ChecksLayer<C, B> {
+    impl<C, B, K> Default for Http1ChecksLayer<C, B, K> {
         fn default() -> Self {
             Self::new()
         }
     }
 
-    impl<C, B> Clone for Http1ChecksLayer<C, B> {
+    impl<C, B, K> Clone for Http1ChecksLayer<C, B, K> {
         fn clone(&self) -> Self {
             Self::new()
         }
     }
 
-    impl<C, B> fmt::Debug for Http1ChecksLayer<C, B> {
+    impl<C, B, K> fmt::Debug for Http1ChecksLayer<C, B, K> {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.debug_struct("Http1ChecksLayer").finish()
         }
     }
 
-    impl<C, B, S> tower::layer::Layer<S> for Http1ChecksLayer<C, B>
+    impl<C, B, K, S> tower::layer::Layer<S> for Http1ChecksLayer<C, B, K>
     where
-        S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
+        S: tower::Service<ExecuteRequest<C, B, K>, Error = Error>,
         C: Connection<B> + PoolableConnection,
+        K: Key,
     {
-        type Service = Http1ChecksService<S, C, B>;
+        type Service = Http1ChecksService<S, C, B, K>;
 
         fn layer(&self, service: S) -> Self::Service {
             Http1ChecksService::new(service)
         }
     }
 
-    fn check_http1_request<C, B>(
-        mut req: ExecuteRequest<C, B>,
-    ) -> Result<ExecuteRequest<C, B>, Error>
+    fn check_http1_request<C, B, K>(
+        mut req: ExecuteRequest<C, B, K>,
+    ) -> Result<ExecuteRequest<C, B, K>, Error>
     where
         C: Connection<B> + PoolableConnection,
+        K: Key,
     {
         if req.connection().version() >= http::Version::HTTP_2 {
             return Ok(req);
@@ -303,7 +310,7 @@ pub(super) mod http2 {
     use ::http;
 
     use crate::client::conn::Connection;
-    use crate::client::pool::PoolableConnection;
+    use crate::client::pool::{Key, PoolableConnection};
     use crate::client::Error;
     use crate::service::client::ExecuteRequest;
     use crate::service::error::{MaybeErrorFuture, PreprocessService};
@@ -316,32 +323,36 @@ pub(super) mod http2 {
         http::header::UPGRADE,
     ];
 
-    type PreprocessFn<C, B, E> = fn(ExecuteRequest<C, B>) -> Result<ExecuteRequest<C, B>, E>;
+    type PreprocessFn<C, B, K, E> =
+        fn(ExecuteRequest<C, B, K>) -> Result<ExecuteRequest<C, B, K>, E>;
 
     /// A service that checks if the request is HTTP/2 compatible.
     #[derive(Debug)]
-    pub struct Http2ChecksService<S, C, B>
+    pub struct Http2ChecksService<S, C, B, K>
     where
-        S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
+        S: tower::Service<ExecuteRequest<C, B, K>, Error = Error>,
         C: Connection<B> + PoolableConnection,
+        K: Key,
     {
-        inner: PreprocessService<S, PreprocessFn<C, B, S::Error>>,
+        inner: PreprocessService<S, PreprocessFn<C, B, K, S::Error>>,
     }
 
-    impl<S, C, B> Clone for Http2ChecksService<S, C, B>
+    impl<S, C, B, K> Clone for Http2ChecksService<S, C, B, K>
     where
-        S: tower::Service<ExecuteRequest<C, B>, Error = Error> + Clone,
+        S: tower::Service<ExecuteRequest<C, B, K>, Error = Error> + Clone,
         C: Connection<B> + PoolableConnection,
+        K: Key,
     {
         fn clone(&self) -> Self {
             Self::new(self.inner.service().clone())
         }
     }
 
-    impl<S, C, B> Http2ChecksService<S, C, B>
+    impl<S, C, B, K> Http2ChecksService<S, C, B, K>
     where
-        S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
+        S: tower::Service<ExecuteRequest<C, B, K>, Error = Error>,
         C: Connection<B> + PoolableConnection,
+        K: Key,
     {
         /// Create a new `Http2ChecksService`.
         pub fn new(inner: S) -> Self {
@@ -351,11 +362,12 @@ pub(super) mod http2 {
         }
     }
 
-    fn check_http2_request<C, B>(
-        mut req: ExecuteRequest<C, B>,
-    ) -> Result<ExecuteRequest<C, B>, Error>
+    fn check_http2_request<C, B, K>(
+        mut req: ExecuteRequest<C, B, K>,
+    ) -> Result<ExecuteRequest<C, B, K>, Error>
     where
         C: Connection<B> + PoolableConnection,
+        K: Key,
     {
         if req.connection().version() == http::Version::HTTP_2 {
             if req.request().method() == http::Method::CONNECT {
@@ -390,10 +402,11 @@ pub(super) mod http2 {
         Ok(req)
     }
 
-    impl<S, C, B> tower::Service<ExecuteRequest<C, B>> for Http2ChecksService<S, C, B>
+    impl<S, C, B, K> tower::Service<ExecuteRequest<C, B, K>> for Http2ChecksService<S, C, B, K>
     where
-        S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
+        S: tower::Service<ExecuteRequest<C, B, K>, Error = Error>,
         C: Connection<B> + PoolableConnection,
+        K: Key,
     {
         type Response = S::Response;
 
@@ -407,17 +420,17 @@ pub(super) mod http2 {
         }
 
         #[inline]
-        fn call(&mut self, req: ExecuteRequest<C, B>) -> Self::Future {
+        fn call(&mut self, req: ExecuteRequest<C, B, K>) -> Self::Future {
             self.inner.call(req)
         }
     }
 
     /// A `Layer` that applies HTTP/2 checks to requests.
-    pub struct Http2ChecksLayer<C, B> {
-        _marker: std::marker::PhantomData<fn(C, B)>,
+    pub struct Http2ChecksLayer<C, B, K> {
+        _marker: std::marker::PhantomData<fn(C, B, K)>,
     }
 
-    impl<C, B> Http2ChecksLayer<C, B> {
+    impl<C, B, K> Http2ChecksLayer<C, B, K> {
         /// Create a new `Http2ChecksLayer`.
         pub fn new() -> Self {
             Self {
@@ -426,30 +439,31 @@ pub(super) mod http2 {
         }
     }
 
-    impl<C, B> Default for Http2ChecksLayer<C, B> {
+    impl<C, B, K> Default for Http2ChecksLayer<C, B, K> {
         fn default() -> Self {
             Self::new()
         }
     }
 
-    impl<C, B> fmt::Debug for Http2ChecksLayer<C, B> {
+    impl<C, B, K> fmt::Debug for Http2ChecksLayer<C, B, K> {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.debug_struct("Http2ChecksLayer").finish()
         }
     }
 
-    impl<C, B> Clone for Http2ChecksLayer<C, B> {
+    impl<C, B, K> Clone for Http2ChecksLayer<C, B, K> {
         fn clone(&self) -> Self {
             Self::new()
         }
     }
 
-    impl<S, C, B> tower::layer::Layer<S> for Http2ChecksLayer<C, B>
+    impl<S, C, B, K> tower::layer::Layer<S> for Http2ChecksLayer<C, B, K>
     where
-        S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
+        S: tower::Service<ExecuteRequest<C, B, K>, Error = Error>,
         C: Connection<B> + PoolableConnection,
+        K: Key,
     {
-        type Service = Http2ChecksService<S, C, B>;
+        type Service = Http2ChecksService<S, C, B, K>;
 
         fn layer(&self, inner: S) -> Self::Service {
             Http2ChecksService::new(inner)


### PR DESCRIPTION
This defaults to `(scheme, authority)` as the key, but it allows
users to provide their own key type if they want to.
