### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/alexrudy/hyperdriver/compare/v0.7.0...v0.8.0) - 2024-10-21
+
+### <!-- 0 -->⛰️ Features
+
+- Make connection pool generic over the key type
+- Client pool can delay drop for checkout
+- Client now uses Body type instead of Incoming for response bodies
+
+### <!-- 1 -->🐛 Bug Fixes
+
+- single threaded example pool key
+- make connection trait object safe
+- AcceptorCore and Braid should be opaque
+- Mark errors as non_exhaustive
+- Ensure that feature combinations compile in —test mode
+
+### <!-- 2 -->🚜 Refactor
+
+- consolidate BoxError and BoxFuture into common type aliases
+
 ## [0.7.0](https://github.com/alexrudy/hyperdriver/compare/v0.6.0...v0.7.0) - 2024-10-01
 
 ### <!-- 0 -->⛰️ Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "hyperdriver"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "axum",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperdriver"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "The missing middle for Hyper - Servers and Clients with ergonomic APIs"
 license = "MIT"


### PR DESCRIPTION
## 🤖 New release
* `hyperdriver`: 0.7.0 -> 0.8.0 (⚠️ API breaking changes)

### ⚠️ `hyperdriver` breaking changes

```
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum SNIMiddlewareError in /tmp/.tmpaFua8O/hyperdriver/src/server/conn/tls/sni.rs:19
  enum ConnectionError in /tmp/.tmpaFua8O/hyperdriver/src/client/conn/connection.rs:200
  enum UriError in /tmp/.tmpaFua8O/hyperdriver/src/client/pool/mod.rs:79
  enum ConnectionError in /tmp/.tmpaFua8O/hyperdriver/src/server/conn/mod.rs:41
  enum ServerError in /tmp/.tmpaFua8O/hyperdriver/src/server/mod.rs:553
  enum TlsConnectionError in /tmp/.tmpaFua8O/hyperdriver/src/client/conn/transport/mod.rs:159
  enum Protocol in /tmp/.tmpaFua8O/hyperdriver/src/info/mod.rs:34
  enum Error in /tmp/.tmpaFua8O/hyperdriver/src/client/error.rs:9
  enum ValidateSNIError in /tmp/.tmpaFua8O/hyperdriver/src/server/conn/tls/sni.rs:44

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_missing.ron

Failed in:
  enum hyperdriver::server::conn::AcceptorCore, previously in file /tmp/.tmpyR0nKq/hyperdriver/src/server/conn/acceptor.rs:72
  enum hyperdriver::stream::Braid, previously in file /tmp/.tmpyR0nKq/hyperdriver/src/stream/core.rs:23

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/method_parameter_count_changed.ron

Failed in:
  hyperdriver::server::Server::new now takes 4 parameters instead of 3, in /tmp/.tmpaFua8O/hyperdriver/src/server/mod.rs:182
  hyperdriver::Server::new now takes 4 parameters instead of 3, in /tmp/.tmpaFua8O/hyperdriver/src/server/mod.rs:182

--- failure struct_marked_non_exhaustive: struct marked #[non_exhaustive] ---

Description:
A public struct has been marked #[non_exhaustive], which will prevent it from being constructed using a struct literal outside of its crate. It previously had no private fields, so a struct literal could be used to construct it outside its crate.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/struct_marked_non_exhaustive.ron

Failed in:
  struct TcpTransportConfig in /tmp/.tmpaFua8O/hyperdriver/src/client/conn/transport/tcp.rs:441
  struct Config in /tmp/.tmpaFua8O/hyperdriver/src/client/pool/mod.rs:399
  struct Config in /tmp/.tmpaFua8O/hyperdriver/src/client/pool/mod.rs:399

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field continue_after_premeption of struct Config, previously in file /tmp/.tmpyR0nKq/hyperdriver/src/client/pool/mod.rs:338
  field continue_after_premeption of struct Config, previously in file /tmp/.tmpyR0nKq/hyperdriver/src/client/pool/mod.rs:338

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/trait_method_missing.ron

Failed in:
  method when_ready of trait Connection, previously in file /tmp/.tmpyR0nKq/hyperdriver/src/client/conn/connection.rs:41
  method when_ready of trait Connection, previously in file /tmp/.tmpyR0nKq/hyperdriver/src/client/conn/connection.rs:41

--- failure trait_no_longer_object_safe: trait no longer object safe ---

Description:
Trait is no longer object safe, which breaks `dyn Trait` usage.
        ref: https://doc.rust-lang.org/stable/reference/items/traits.html#object-safety
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/trait_no_longer_object_safe.ron

Failed in:
  trait TlsHandshakeStream in file /tmp/.tmpaFua8O/hyperdriver/src/stream/tls.rs:44
  trait TlsHandshakeExt in file /tmp/.tmpaFua8O/hyperdriver/src/stream/tls.rs:178
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.0](https://github.com/alexrudy/hyperdriver/compare/v0.7.0...v0.8.0) - 2024-10-21

### <!-- 0 -->⛰️ Features

- Make connection pool generic over the key type
- Client pool can delay drop for checkout
- Client now uses Body type instead of Incoming for response bodies

### <!-- 1 -->🐛 Bug Fixes

- single threaded example pool key
- make connection trait object safe
- AcceptorCore and Braid should be opaque
- Mark errors as non_exhaustive
- Ensure that feature combinations compile in —test mode

### <!-- 2 -->🚜 Refactor

- consolidate BoxError and BoxFuture into common type aliases
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).