### PR TITLE
chore: release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1](https://github.com/alexrudy/hyperdriver/compare/v0.8.0...v0.8.1) - 2024-10-24
+
+### <!-- 0 -->⛰️ Features
+
+- Client pool interns keys
+
 ## [0.8.0](https://github.com/alexrudy/hyperdriver/compare/v0.7.0...v0.8.0) - 2024-10-21
 
 ### <!-- 0 -->⛰️ Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "hyperdriver"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "axum",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperdriver"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 description = "The missing middle for Hyper - Servers and Clients with ergonomic APIs"
 license = "MIT"


### PR DESCRIPTION
## 🤖 New release
* `hyperdriver`: 0.8.0 -> 0.8.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.1](https://github.com/alexrudy/hyperdriver/compare/v0.8.0...v0.8.1) - 2024-10-24

### <!-- 0 -->⛰️ Features

- Client pool interns keys
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).