### PR TITLE
feat: Client pool interns keys

### DIFF
--- a/examples/single_threaded.rs
+++ b/examples/single_threaded.rs
@@ -295,13 +295,13 @@ async fn http2_client(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let client = tower::ServiceBuilder::new()
         .layer(
-            ConnectionPoolLayer::new(
+            ConnectionPoolLayer::<_, _, _, UriKey>::new(
                 TcpTransport::<_, TcpStream>::default().without_tls(),
                 auto::HttpConnectionBuilder::<Body>::default(),
             )
             .with_optional_pool(Some(Default::default())),
         )
-        .service(RequestExecutor::<HttpConnection<Body>, _, UriKey>::new());
+        .service(RequestExecutor::<HttpConnection<Body>, _>::new());
 
     let authority = url.authority().unwrap().clone();
 

--- a/justfile
+++ b/justfile
@@ -141,6 +141,9 @@ httpbin:
 hurl *args='':
     cargo +{{rust}} run --features client,tls,tls-ring --example hurl -- {{args}}
 
+profile:
+    cargo +{{rust}} run --release --features client,tls,tls-ring --example profile
+
 # Launch jaeger
 jaeger:
     docker run -d -p16686:16686 -p4317:4317 -e COLLECTOR_OTLP_ENABLED=true jaegertracing/all-in-one:latest

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -18,7 +18,7 @@ use super::conn::transport::TransportExt;
 use super::conn::Connection;
 use super::conn::Protocol;
 use super::conn::Transport;
-use super::pool::{self, PoolableConnection, PoolableStream};
+use super::pool::{PoolableConnection, PoolableStream, UriKey};
 use super::ConnectionPoolLayer;
 use crate::service::RequestExecutor;
 use crate::service::{Http1ChecksLayer, Http2ChecksLayer, SetHostHeaderLayer};
@@ -459,11 +459,11 @@ where
             ))
             .layer(IncomingResponseLayer::new())
             .layer(
-                ConnectionPoolLayer::new(transport, self.protocol.build())
+                ConnectionPoolLayer::<_, _, _, UriKey>::new(transport, self.protocol.build())
                     .with_optional_pool(self.pool.clone()),
             )
             .layer(SetHostHeaderLayer::new())
-            .layer(Http2ChecksLayer::<_, _, pool::UriKey>::new())
+            .layer(Http2ChecksLayer::new())
             .layer(Http1ChecksLayer::new())
             .service(RequestExecutor::new());
 

--- a/src/client/pool/key.rs
+++ b/src/client/pool/key.rs
@@ -112,7 +112,6 @@ impl FromStr for UriKey {
 
 #[cfg(test)]
 pub(crate) mod test_key {
-    use std::usize;
 
     use super::*;
 
@@ -164,8 +163,10 @@ pub(crate) mod test_key {
 
     #[test]
     fn token_wrap() {
-        let mut map = TokenMap::default();
-        map.counter = NonZeroUsize::new(usize::MAX).unwrap();
+        let mut map = TokenMap {
+            counter: NonZeroUsize::new(usize::MAX).unwrap(),
+            ..Default::default()
+        };
         let token = map.insert("key");
         assert_eq!(token.0, Some(NonZeroUsize::new(usize::MAX).unwrap()));
 

--- a/src/client/pool/key.rs
+++ b/src/client/pool/key.rs
@@ -1,6 +1,68 @@
-use std::{fmt, str::FromStr};
+use std::{collections::HashMap, fmt, num::NonZeroUsize, str::FromStr};
 
 use super::UriError;
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Token(Option<NonZeroUsize>);
+
+impl Token {
+    pub fn zero() -> Self {
+        Token(None)
+    }
+
+    #[allow(dead_code)]
+    pub fn is_zero(&self) -> bool {
+        self.0.is_none()
+    }
+}
+
+impl fmt::Debug for Token {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            Some(value) => write!(f, "Token({})", value),
+            None => write!(f, "Token(0)"),
+        }
+    }
+}
+
+pub(crate) struct TokenMap<K> {
+    counter: NonZeroUsize,
+    map: HashMap<K, Token>,
+}
+
+impl<K> fmt::Debug for TokenMap<K> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TokenMap")
+            .field("counter", &self.counter)
+            .finish()
+    }
+}
+
+impl<K> Default for TokenMap<K> {
+    fn default() -> Self {
+        Self {
+            counter: NonZeroUsize::new(1).unwrap(),
+            map: HashMap::new(),
+        }
+    }
+}
+
+impl<K> TokenMap<K>
+where
+    K: Eq + std::hash::Hash,
+{
+    pub fn insert(&mut self, key: K) -> Token {
+        *self.map.entry(key).or_insert_with(|| {
+            let token = Token(Some(self.counter));
+            self.counter = self
+                .counter
+                .checked_add(1)
+                .or(NonZeroUsize::new(1))
+                .unwrap();
+            token
+        })
+    }
+}
 
 /// Pool key which is used to identify a connection - using scheme
 /// and authority.
@@ -50,6 +112,8 @@ impl FromStr for UriKey {
 
 #[cfg(test)]
 pub(crate) mod test_key {
+    use std::usize;
+
     use super::*;
 
     #[test]
@@ -96,5 +160,19 @@ pub(crate) mod test_key {
             format!("{:?}", key),
             "UriKey(\"http\", Some(localhost:8080))"
         );
+    }
+
+    #[test]
+    fn token_wrap() {
+        let mut map = TokenMap::default();
+        map.counter = NonZeroUsize::new(usize::MAX).unwrap();
+        let token = map.insert("key");
+        assert_eq!(token.0, Some(NonZeroUsize::new(usize::MAX).unwrap()));
+
+        let token = map.insert("bar");
+        assert_eq!(token.0, Some(NonZeroUsize::new(1).unwrap()));
+
+        assert_eq!(map.insert("bar"), token);
+        assert_ne!(map.insert("key"), token);
     }
 }

--- a/src/service/host.rs
+++ b/src/service/host.rs
@@ -91,11 +91,10 @@ where
     }
 }
 
-impl<S, B, C, K> tower::Service<ExecuteRequest<C, B, K>> for SetHostHeader<S>
+impl<S, B, C> tower::Service<ExecuteRequest<C, B>> for SetHostHeader<S>
 where
-    S: tower::Service<ExecuteRequest<C, B, K>>,
+    S: tower::Service<ExecuteRequest<C, B>>,
     C: Connection<B> + PoolableConnection,
-    K: crate::client::pool::Key,
 {
     type Response = S::Response;
 
@@ -110,7 +109,7 @@ where
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, mut req: ExecuteRequest<C, B, K>) -> Self::Future {
+    fn call(&mut self, mut req: ExecuteRequest<C, B>) -> Self::Future {
         if req.connection().version() < http::Version::HTTP_2 {
             set_host_header(req.request_mut());
         }


### PR DESCRIPTION
By replacing most direct uses of connection keys with an opaque token, many client types no longer require the generic argument for the key type, greatly simplifying the implementation.

Connection pool keys are converted to opaque, copyable tokens when checkouts are created from the pool, with keys that hash equivalently returning the same token. Then the pool uses these tokens in place of the keys in internal data structures.
