### PR TITLE
chore: release v0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "hyperdriver"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "axum",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperdriver"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "The missing middle for Hyper - Servers and Clients with ergonomic APIs"
 license = "MIT"


### PR DESCRIPTION
## 🤖 New release
* `hyperdriver`: 0.8.1 -> 0.8.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.0](https://github.com/alexrudy/hyperdriver/compare/v0.7.0...v0.8.0) - 2024-10-21

### <!-- 0 -->⛰️ Features

- Make connection pool generic over the key type
- Client pool can delay drop for checkout
- Client now uses Body type instead of Incoming for response bodies

### <!-- 1 -->🐛 Bug Fixes

- single threaded example pool key
- make connection trait object safe
- AcceptorCore and Braid should be opaque
- Mark errors as non_exhaustive
- Ensure that feature combinations compile in —test mode

### <!-- 2 -->🚜 Refactor

- consolidate BoxError and BoxFuture into common type aliases
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).