### PR TITLE
chore: release v0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.4](https://github.com/alexrudy/hyperdriver/compare/v0.8.3...v0.8.4) - 2024-12-10
+
+### <!-- 0 -->⛰️ Features
+
+- Client connection upgrade support
+
+### <!-- 1 -->🐛 Bug Fixes
+
+- upgrades test doesn’t require TLS
+
 ## [0.8.0](https://github.com/alexrudy/hyperdriver/compare/v0.7.0...v0.8.0) - 2024-10-21
 
 ### <!-- 0 -->⛰️ Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "hyperdriver"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "axum",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperdriver"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 description = "The missing middle for Hyper - Servers and Clients with ergonomic APIs"
 license = "MIT"


### PR DESCRIPTION
## 🤖 New release
* `hyperdriver`: 0.8.3 -> 0.8.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.4](https://github.com/alexrudy/hyperdriver/compare/v0.8.3...v0.8.4) - 2024-12-10

### <!-- 0 -->⛰️ Features

- Client connection upgrade support

### <!-- 1 -->🐛 Bug Fixes

- upgrades test doesn’t require TLS
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).