### PR TITLE
chore: release v0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.5](https://github.com/alexrudy/hyperdriver/compare/v0.8.4...v0.8.5) - 2024-12-12
+
+### <!-- 0 -->⛰️ Features
+
+- client Transport trait now accepts http::request::Parts
+- Allow client services to support a custom body type
+
 ## [0.8.4](https://github.com/alexrudy/hyperdriver/compare/v0.8.3...v0.8.4) - 2024-12-10
 
 ### <!-- 0 -->⛰️ Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "hyperdriver"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "axum",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperdriver"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2021"
 description = "The missing middle for Hyper - Servers and Clients with ergonomic APIs"
 license = "MIT"


### PR DESCRIPTION
## 🤖 New release
* `hyperdriver`: 0.8.4 -> 0.8.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.5](https://github.com/alexrudy/hyperdriver/compare/v0.8.4...v0.8.5) - 2024-12-12

### <!-- 0 -->⛰️ Features

- client Transport trait now accepts http::request::Parts
- Allow client services to support a custom body type
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).