### PR TITLE
feat: client Transport trait now accepts http::request::Parts

### DIFF
--- a/examples/single_threaded.rs
+++ b/examples/single_threaded.rs
@@ -29,6 +29,7 @@ use hyperdriver::info::HasConnectionInfo;
 use hyperdriver::server::Accept;
 use hyperdriver::service::{make_service_fn, RequestExecutor};
 use hyperdriver::stream::TcpStream;
+use hyperdriver::IntoRequestParts;
 use pin_project::pin_project;
 use tokio::io::{self, AsyncWriteExt};
 use tokio::net::TcpListener;
@@ -391,8 +392,8 @@ impl Transport for TransportNotSend {
 
     type Future = Pin<Box<dyn Future<Output = Result<Self::IO, Self::Error>> + Send>>;
 
-    fn connect(&mut self, uri: http::Uri) -> <Self as Transport>::Future {
-        self.tcp.connect(uri).boxed()
+    fn connect<R: IntoRequestParts>(&mut self, req: R) -> <Self as Transport>::Future {
+        self.tcp.connect(req.into_request_parts()).boxed()
     }
 
     fn poll_ready(

--- a/src/client/conn/transport/mock.rs
+++ b/src/client/conn/transport/mock.rs
@@ -2,7 +2,6 @@
 
 use std::future::ready;
 
-use http::Uri;
 use thiserror::Error;
 
 use crate::client::conn::protocol::mock::MockProtocol;
@@ -81,14 +80,14 @@ impl MockTransport {
     /// Create a new connector for the transport.
     pub fn connector(
         self,
-        uri: Uri,
+        parts: http::request::Parts,
         version: HttpProtocol,
     ) -> pool::Connector<Self, MockProtocol, crate::Body> {
-        pool::Connector::new(self, MockProtocol::default(), uri, version)
+        pool::Connector::new(self, MockProtocol::default(), parts, version)
     }
 }
 
-impl tower::Service<http::Uri> for MockTransport {
+impl tower::Service<http::request::Parts> for MockTransport {
     type Response = MockStream;
 
     type Error = MockConnectionError;
@@ -102,7 +101,7 @@ impl tower::Service<http::Uri> for MockTransport {
         std::task::Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, _req: http::Uri) -> Self::Future {
+    fn call(&mut self, _req: http::request::Parts) -> Self::Future {
         let reuse = match &mut self.mode {
             TransportMode::SingleUse => false,
             TransportMode::Reusable => true,

--- a/src/client/pool/mod.rs
+++ b/src/client/pool/mod.rs
@@ -532,6 +532,7 @@ mod tests {
 
     use crate::client::conn::protocol::HttpProtocol;
     use crate::client::conn::transport::mock::MockConnectionError;
+    use crate::helpers::IntoRequestParts;
 
     use super::*;
     use crate::client::conn::protocol::mock::MockSender;
@@ -577,7 +578,7 @@ mod tests {
                 key.clone(),
                 false,
                 MockTransport::single()
-                    .connector("mock://address".parse().unwrap(), HttpProtocol::Http1),
+                    .connector("mock://address".into_request_parts(), HttpProtocol::Http1),
             )
             .await
             .unwrap();
@@ -591,7 +592,7 @@ mod tests {
                 key.clone(),
                 false,
                 MockTransport::single()
-                    .connector("mock://address".parse().unwrap(), HttpProtocol::Http1),
+                    .connector("mock://address".into_request_parts(), HttpProtocol::Http1),
             )
             .await
             .unwrap();
@@ -606,7 +607,7 @@ mod tests {
                 key,
                 false,
                 MockTransport::single()
-                    .connector("mock://address".parse().unwrap(), HttpProtocol::Http1),
+                    .connector("mock://address".into_request_parts(), HttpProtocol::Http1),
             )
             .await
             .unwrap();
@@ -632,7 +633,7 @@ mod tests {
                 key.clone(),
                 true,
                 MockTransport::reusable()
-                    .connector("mock://address".parse().unwrap(), HttpProtocol::Http1),
+                    .connector("mock://address".into_request_parts(), HttpProtocol::Http1),
             )
             .await
             .unwrap();
@@ -646,7 +647,7 @@ mod tests {
                 key.clone(),
                 true,
                 MockTransport::reusable()
-                    .connector("mock://address".parse().unwrap(), HttpProtocol::Http1),
+                    .connector("mock://address".into_request_parts(), HttpProtocol::Http1),
             )
             .await
             .unwrap();
@@ -661,7 +662,7 @@ mod tests {
                 key.clone(),
                 true,
                 MockTransport::reusable()
-                    .connector("mock://address".parse().unwrap(), HttpProtocol::Http1),
+                    .connector("mock://address".into_request_parts(), HttpProtocol::Http1),
             )
             .await
             .unwrap();
@@ -686,7 +687,7 @@ mod tests {
             key.clone(),
             true,
             MockTransport::channel(rx)
-                .connector("mock://address".parse().unwrap(), HttpProtocol::Http1)
+                .connector("mock://address".into_request_parts(), HttpProtocol::Http1)
         ));
 
         assert!(futures_util::poll!(&mut checkout_a).is_pending());
@@ -695,7 +696,7 @@ mod tests {
             key.clone(),
             true,
             MockTransport::reusable()
-                .connector("mock://address".parse().unwrap(), HttpProtocol::Http1),
+                .connector("mock://address".into_request_parts(), HttpProtocol::Http1),
         ));
 
         assert!(futures_util::poll!(&mut checkout_b).is_pending());
@@ -730,7 +731,7 @@ mod tests {
             key.clone(),
             false,
             MockTransport::single()
-                .connector("mock://address".parse().unwrap(), HttpProtocol::Http1),
+                .connector("mock://address".into_request_parts(), HttpProtocol::Http1),
         );
 
         let token = checkout.token();
@@ -768,7 +769,7 @@ mod tests {
             key.clone(),
             false,
             MockTransport::single()
-                .connector("mock://address".parse().unwrap(), HttpProtocol::Http1),
+                .connector("mock://address".into_request_parts(), HttpProtocol::Http1),
         );
 
         let token = checkout.token();
@@ -813,14 +814,14 @@ mod tests {
             key.clone(),
             true,
             MockTransport::reusable()
-                .connector("mock://address".parse().unwrap(), HttpProtocol::Http1),
+                .connector("mock://address".into_request_parts(), HttpProtocol::Http1),
         );
 
         let checkout = pool.checkout(
             key.clone(),
             true,
             MockTransport::reusable()
-                .connector("mock://address".parse().unwrap(), HttpProtocol::Http1),
+                .connector("mock://address".into_request_parts(), HttpProtocol::Http1),
         );
 
         drop(start);
@@ -845,7 +846,7 @@ mod tests {
             key.clone(),
             true,
             MockTransport::reusable()
-                .connector("mock://address".parse().unwrap(), HttpProtocol::Http1),
+                .connector("mock://address".into_request_parts(), HttpProtocol::Http1),
         );
 
         drop(pool);
@@ -869,7 +870,7 @@ mod tests {
             key.clone(),
             true,
             MockTransport::error()
-                .connector("mock://address".parse().unwrap(), HttpProtocol::Http1),
+                .connector("mock://address".into_request_parts(), HttpProtocol::Http1),
         );
 
         let outcome = checkout.now_or_never().unwrap();
@@ -895,7 +896,7 @@ mod tests {
                 key.clone(),
                 false,
                 MockTransport::single()
-                    .connector("mock://address".parse().unwrap(), HttpProtocol::Http1),
+                    .connector("mock://address".into_request_parts(), HttpProtocol::Http1),
             )
             .await
             .unwrap();
@@ -909,7 +910,7 @@ mod tests {
                 key.clone(),
                 false,
                 MockTransport::single()
-                    .connector("mock://address".parse().unwrap(), HttpProtocol::Http1),
+                    .connector("mock://address".into_request_parts(), HttpProtocol::Http1),
             )
             .await
             .unwrap();
@@ -924,7 +925,7 @@ mod tests {
                 key,
                 false,
                 MockTransport::single()
-                    .connector("mock://address".parse().unwrap(), HttpProtocol::Http1),
+                    .connector("mock://address".into_request_parts(), HttpProtocol::Http1),
             )
             .await
             .unwrap();
@@ -950,7 +951,7 @@ mod tests {
                 key.clone(),
                 false,
                 MockTransport::single()
-                    .connector("mock://address".parse().unwrap(), HttpProtocol::Http1),
+                    .connector("mock://address".into_request_parts(), HttpProtocol::Http1),
             )
             .await
             .unwrap();
@@ -962,7 +963,7 @@ mod tests {
             key.clone(),
             false,
             MockTransport::single()
-                .connector("mock://address".parse().unwrap(), HttpProtocol::Http1),
+                .connector("mock://address".into_request_parts(), HttpProtocol::Http1),
         );
 
         let token = checkout.token();

--- a/src/client/pool/service.rs
+++ b/src/client/pool/service.rs
@@ -231,12 +231,7 @@ where
         let transport = self.transport.clone();
         let http_protocol = request_parts.version.into();
 
-        let connector = Connector::new(
-            transport,
-            protocol,
-            request_parts.uri.clone(),
-            http_protocol,
-        );
+        let connector = Connector::new(transport, protocol, request_parts.clone(), http_protocol);
 
         if let Some(pool) = self.pool.as_ref() {
             tracing::trace!(?key, "checking out connection");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,8 @@ pub use client::Client;
 #[cfg(feature = "server")]
 pub use server::Server;
 
+pub use helpers::IntoRequestParts;
+
 type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
@@ -165,6 +167,34 @@ pub(crate) mod private {
 
     #[allow(unused)]
     pub trait Sealed<T> {}
+}
+
+/// Helpers to turn URI-like items into empty request parts
+pub(crate) mod helpers {
+
+    /// Turn the item into http::request::Parts infallibly
+    pub trait IntoRequestParts {
+        /// Produce http::request::Parts
+        fn into_request_parts(self) -> http::request::Parts;
+    }
+
+    impl IntoRequestParts for &str {
+        fn into_request_parts(self) -> http::request::Parts {
+            http::Request::get(self).body(()).unwrap().into_parts().0
+        }
+    }
+
+    impl IntoRequestParts for http::Uri {
+        fn into_request_parts(self) -> http::request::Parts {
+            http::Request::get(self).body(()).unwrap().into_parts().0
+        }
+    }
+
+    impl IntoRequestParts for http::request::Parts {
+        fn into_request_parts(self) -> http::request::Parts {
+            self
+        }
+    }
 }
 
 /// Test fixtures for the `hyperdriver` crate.

--- a/src/server/conn/tls/mod.rs
+++ b/src/server/conn/tls/mod.rs
@@ -193,7 +193,7 @@ mod tests {
 
     use tracing::Instrument as _;
 
-    use crate::fixtures;
+    use crate::{fixtures, IntoRequestParts};
 
     use crate::client::conn::transport::duplex::DuplexTransport;
     use crate::client::conn::transport::TransportExt as _;
@@ -223,7 +223,7 @@ mod tests {
 
         let client = async move {
             let mut stream = client
-                .connect("https://example.com".parse().unwrap())
+                .connect("https://example.com".into_request_parts())
                 .await
                 .unwrap();
 


### PR DESCRIPTION
This is so that clients can support things like session pinning when used as part of a load balancer.

To use a Service<Uri> as a tranpsort, wrap it in the UriTransport type.

BREAKING: The signature of the connect() method on Transport has changed.