### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/alexrudy/hyperdriver/compare/v0.8.5...v0.9.0) - 2025-03-18
+
+### <!-- 0 -->⛰️ Features
+
+- Transport trait is dyn-compatible
+- Add generic body type to PoolableConnection
+- Connector Service
+- Expose the client connector publicly.
+- *(client)* Flexible APIs to leverage the TCP transport
+
 ## [0.8.5](https://github.com/alexrudy/hyperdriver/compare/v0.8.4...v0.8.5) - 2024-12-12
 
 ### <!-- 0 -->⛰️ Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "hyperdriver"
-version = "0.8.5"
+version = "0.9.0"
 dependencies = [
  "axum 0.8.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperdriver"
-version = "0.8.5"
+version = "0.9.0"
 edition = "2021"
 description = "The missing middle for Hyper - Servers and Clients with ergonomic APIs"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `hyperdriver`: 0.8.5 -> 0.9.0 (⚠ API breaking changes)

### ⚠ `hyperdriver` breaking changes

```text
--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  hyperdriver::client::conn::stream::TlsStream::connect takes 1 generic types instead of 0, in /tmp/.tmpTKxw9A/hyperdriver/src/client/conn/stream/tls.rs:118

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait hyperdriver::client::pool::PoolableConnection gained Connection in file /tmp/.tmpTKxw9A/hyperdriver/src/client/pool/mod.rs:478

--- failure trait_method_requires_different_generic_type_params: trait method now requires a different number of generic type parameters ---

Description:
A trait method now requires a different number of generic type parameters than it used to. Calls or implementations of this trait method using the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/trait_method_requires_different_generic_type_params.ron

Failed in:
  Transport::connect (1 -> 0 generic types) in /tmp/.tmpTKxw9A/hyperdriver/src/client/conn/transport/mod.rs:57
  Transport::connect (1 -> 0 generic types) in /tmp/.tmpTKxw9A/hyperdriver/src/client/conn/transport/mod.rs:57

--- failure trait_requires_more_generic_type_params: trait now requires more generic type parameters ---

Description:
A trait now requires more generic type parameters than it used to. Uses of this trait that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/trait_requires_more_generic_type_params.ron

Failed in:
  trait Pooled (1 -> 2 required generic types) in /tmp/.tmpTKxw9A/hyperdriver/src/client/pool/mod.rs:501

--- failure type_requires_more_generic_type_params: type now requires more generic type parameters ---

Description:
A type now requires more generic type parameters than it used to. Uses of this type that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/type_requires_more_generic_type_params.ron

Failed in:
  Struct Pooled (1 -> 2 required generic types) in /tmp/.tmpTKxw9A/hyperdriver/src/client/pool/mod.rs:501
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.0](https://github.com/alexrudy/hyperdriver/compare/v0.8.5...v0.9.0) - 2025-03-18

### <!-- 0 -->⛰️ Features

- Transport trait is dyn-compatible
- Add generic body type to PoolableConnection
- Connector Service
- Expose the client connector publicly.
- *(client)* Flexible APIs to leverage the TCP transport
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).