### PR TITLE
TCP Transport Flexibility

### DIFF
--- a/src/client/conn/stream/tls.rs
+++ b/src/client/conn/stream/tls.rs
@@ -8,8 +8,8 @@ use std::{fmt, io};
 use std::{future::Future, pin::Pin};
 
 use rustls::ClientConfig;
+use std::net::ToSocketAddrs;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-use tokio::net::ToSocketAddrs;
 
 use crate::client::pool::PoolableStream;
 use crate::info::tls::HasTlsConnectionInfo;
@@ -115,8 +115,8 @@ where
 
 impl TlsStream<TcpStream> {
     /// Connect to the given tcp address, using the given domain name and TLS configuration.
-    pub async fn connect(
-        addr: impl ToSocketAddrs,
+    pub async fn connect<A: ToSocketAddrs + Send + 'static>(
+        addr: A,
         domain: &str,
         config: Arc<ClientConfig>,
     ) -> io::Result<Self> {

--- a/src/client/conn/transport/duplex.rs
+++ b/src/client/conn/transport/duplex.rs
@@ -49,9 +49,9 @@ impl tower::Service<http::request::Parts> for DuplexTransport {
 
 #[cfg(all(test, feature = "server"))]
 mod tests {
-    use tower::ServiceExt;
 
     use super::*;
+    use crate::client::conn::transport::TransportExt as _;
     use crate::info::DuplexAddr;
     use crate::info::HasConnectionInfo as _;
     use crate::server::conn::AcceptExt as _;
@@ -63,18 +63,7 @@ mod tests {
         let transport = DuplexTransport::new(1024, client);
 
         let (io, _) = tokio::join!(
-            async {
-                transport
-                    .oneshot(
-                        http::Request::get("https://example.com")
-                            .body(())
-                            .unwrap()
-                            .into_parts()
-                            .0,
-                    )
-                    .await
-                    .unwrap()
-            },
+            async { transport.oneshot("https://example.com").await.unwrap() },
             async { srv.accept().await.unwrap() }
         );
         let info = io.info();

--- a/src/client/conn/transport/stream.rs
+++ b/src/client/conn/transport/stream.rs
@@ -97,7 +97,6 @@ mod tests {
     use crate::client::conn::transport::TransportExt as _;
     use crate::server::conn::AcceptExt as _;
     use crate::IntoRequestParts;
-    use tower::ServiceExt as _;
 
     #[tokio::test]
     async fn transport_into_stream() {

--- a/src/info/mod.rs
+++ b/src/info/mod.rs
@@ -310,12 +310,18 @@ impl<T> HasTlsConnectionInfo for T where T: HasConnectionInfo {}
 
 #[cfg(test)]
 mod tests {
+
+    #[cfg(feature = "client")]
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
     use http::Version;
-    use tokio::net::{TcpListener, UnixListener};
+    #[cfg(feature = "client")]
+    use tokio::net::TcpListener;
+    use tokio::net::UnixListener;
 
-    use crate::stream::{tcp::TcpStream, unix::UnixStream};
+    #[cfg(feature = "client")]
+    use crate::stream::tcp::TcpStream;
+    use crate::stream::unix::UnixStream;
 
     use super::*;
 
@@ -429,6 +435,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "client")]
     async fn tcp_connection_info() {
         let listener = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0))
             .await


### PR DESCRIPTION
feat(client): Flexible APIs to leverage the TCP transport

The client’s TCP connection routine does a bunch of work to set up the TCP socket for HTTP communication. This work is generally not performed by vanilla `tokio::net::TCPStream::connect`, but is performed by hyperdriver’s TCP Transport.

This update makes hyperdriver’s `TCPStream::connect` use the same scheme as the transport under the hood for connection (not for address resolution though).

It also exposes a `.oneshot()` method on transports to connect a transport without using the rest of the hyperdriver infrastructure.
