### PR TITLE
Client Connector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,11 @@ path = "tests/client.rs"
 required-features = ["server", "client", "stream"]
 
 [[test]]
+name = "client-connector"
+path = "tests/client/connector.rs"
+required-features = ["server", "client", "stream"]
+
+[[test]]
 name = "client-custom-body"
 path = "tests/client/custombody.rs"
 required-features = ["server", "client", "stream"]

--- a/examples/single_threaded.rs
+++ b/examples/single_threaded.rs
@@ -23,7 +23,7 @@ use hyperdriver::client::conn::protocol::auto;
 use hyperdriver::client::conn::transport::tcp::{TcpConnectionError, TcpTransport};
 use hyperdriver::client::conn::transport::TransportExt;
 use hyperdriver::client::conn::Transport;
-use hyperdriver::client::pool::UriKey;
+use hyperdriver::client::pool::{Pooled, UriKey};
 use hyperdriver::client::ConnectionPoolLayer;
 use hyperdriver::info::HasConnectionInfo;
 use hyperdriver::server::Accept;
@@ -302,7 +302,7 @@ async fn http2_client(
             )
             .with_optional_pool(Some(Default::default())),
         )
-        .service(RequestExecutor::<HttpConnection<Body>, _>::new());
+        .service(RequestExecutor::<Pooled<HttpConnection<Body>>, _>::new());
 
     let authority = url.authority().unwrap().clone();
 

--- a/examples/single_threaded.rs
+++ b/examples/single_threaded.rs
@@ -302,7 +302,7 @@ async fn http2_client(
             )
             .with_optional_pool(Some(Default::default())),
         )
-        .service(RequestExecutor::<Pooled<HttpConnection<Body>>, _>::new());
+        .service(RequestExecutor::<Pooled<HttpConnection<Body>, Body>, _>::new());
 
     let authority = url.authority().unwrap().clone();
 

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -426,7 +426,7 @@ where
     >>::Target as Protocol<
         super::conn::stream::Stream<<<T as BuildTransport>::Target as Transport>::IO>,
         BIn,
-    >>::Connection: Connection<BIn, ResBody = hyper::body::Incoming> + PoolableConnection,
+    >>::Connection: Connection<BIn, ResBody = hyper::body::Incoming> + PoolableConnection<BIn>,
 
     RP: policy::Policy<BIn, super::Error> + Clone + Send + Sync + 'static,
     S: tower::Layer<SharedService<http::Request<BIn>, http::Response<BOut>, super::Error>>,
@@ -518,7 +518,8 @@ where
     >>::Target as Protocol<
         super::conn::stream::Stream<<<T as BuildTransport>::Target as Transport>::IO>,
         crate::Body,
-    >>::Connection: Connection<crate::Body, ResBody = hyper::body::Incoming> + PoolableConnection,
+    >>::Connection:
+        Connection<crate::Body, ResBody = hyper::body::Incoming> + PoolableConnection<crate::Body>,
 
     RP: policy::Policy<crate::Body, super::Error> + Clone + Send + Sync + 'static,
     S: tower::Layer<

--- a/src/client/conn/connection.rs
+++ b/src/client/conn/connection.rs
@@ -161,22 +161,10 @@ where
     }
 }
 
-impl<B> PoolableConnection for HttpConnection<B>
+impl<B> PoolableConnection<B> for HttpConnection<B>
 where
-    B: Send + 'static,
+    B: HttpBody + Send + 'static,
 {
-    type Error = hyper::Error;
-
-    fn poll_ready(
-        &mut self,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), Self::Error>> {
-        match &mut self.inner {
-            InnerConnection::H2(conn) => conn.poll_ready(cx),
-            InnerConnection::H1(conn) => conn.poll_ready(cx),
-        }
-    }
-
     /// Checks for the connection being open by checking if the underlying connection is ready
     /// to send a new request. If the connection is not ready, it can't be re-used,
     /// so this shortcut isn't harmful.

--- a/src/client/conn/connection.rs
+++ b/src/client/conn/connection.rs
@@ -165,6 +165,18 @@ impl<B> PoolableConnection for HttpConnection<B>
 where
     B: Send + 'static,
 {
+    type Error = hyper::Error;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        match &mut self.inner {
+            InnerConnection::H2(conn) => conn.poll_ready(cx),
+            InnerConnection::H1(conn) => conn.poll_ready(cx),
+        }
+    }
+
     /// Checks for the connection being open by checking if the underlying connection is ready
     /// to send a new request. If the connection is not ready, it can't be re-used,
     /// so this shortcut isn't harmful.

--- a/src/client/conn/connector.rs
+++ b/src/client/conn/connector.rs
@@ -1,0 +1,370 @@
+//! Connectors couple a transport with a protocol to create a connection.
+
+use std::fmt;
+use std::future::Future;
+use std::future::IntoFuture;
+use std::pin::Pin;
+
+use std::task::ready;
+use std::task::Context;
+use std::task::Poll;
+
+use pin_project::pin_project;
+use thiserror::Error;
+use tracing::trace;
+
+use crate::client::conn::protocol::HttpProtocol;
+use crate::client::conn::Protocol;
+use crate::client::conn::Transport;
+use crate::info::ConnectionInfo;
+use crate::info::HasConnectionInfo;
+
+use crate::client::pool::PoolRef;
+use crate::client::pool::PoolableConnection;
+use crate::client::pool::Token;
+
+pub(in crate::client) struct CheckoutMeta {
+    overall_span: tracing::Span,
+    transport_span: Option<tracing::Span>,
+    protocol_span: Option<tracing::Span>,
+}
+
+impl CheckoutMeta {
+    pub(in crate::client) fn new() -> Self {
+        let overall_span = tracing::Span::current();
+
+        Self {
+            overall_span,
+            transport_span: None,
+            protocol_span: None,
+        }
+    }
+
+    pub(in crate::client) fn current(&self) -> &tracing::Span {
+        &self.overall_span
+    }
+
+    pub(in crate::client) fn transport(&mut self) -> &tracing::Span {
+        self.transport_span
+            .get_or_insert_with(|| tracing::trace_span!(parent: &self.overall_span, "transport"))
+    }
+
+    pub(in crate::client) fn protocol(&mut self) -> &tracing::Span {
+        self.protocol_span
+            .get_or_insert_with(|| tracing::trace_span!(parent: &self.overall_span, "protocol"))
+    }
+}
+
+/// Error that can occur during the connection process.
+#[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Error<Transport, Protocol> {
+    /// Error occurred during the connection
+    #[error("creating connection")]
+    Connecting(#[source] Transport),
+
+    /// Error occurred during the handshake
+    #[error("handshaking connection")]
+    Handshaking(#[source] Protocol),
+
+    /// Connection can't even be attempted
+    #[error("connection closed")]
+    Unavailable,
+}
+
+#[pin_project(project = ConnectorStateProjected)]
+enum ConnectorState<T, P, B>
+where
+    T: Transport,
+    P: Protocol<T::IO, B>,
+    P::Connection: PoolableConnection,
+{
+    PollReadyTransport {
+        parts: http::request::Parts,
+        transport: Option<T>,
+        protocol: Option<P>,
+    },
+    Connect {
+        #[pin]
+        future: T::Future,
+        protocol: Option<P>,
+    },
+    PollReadyHandshake {
+        protocol: Option<P>,
+        stream: Option<T::IO>,
+    },
+    Handshake {
+        #[pin]
+        future: <P as Protocol<T::IO, B>>::Future,
+        info: ConnectionInfo<<T::IO as HasConnectionInfo>::Addr>,
+    },
+}
+
+impl<T, P, B> fmt::Debug for ConnectorState<T, P, B>
+where
+    T: Transport,
+    P: Protocol<T::IO, B>,
+    P::Connection: PoolableConnection,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConnectorState::PollReadyTransport { parts, .. } => f
+                .debug_struct("PollReadyTransport")
+                .field("address", &parts.uri)
+                .finish(),
+            ConnectorState::Connect { .. } => f.debug_tuple("Connect").finish(),
+            ConnectorState::PollReadyHandshake { .. } => {
+                f.debug_tuple("PollReadyHandshake").finish()
+            }
+            ConnectorState::Handshake { .. } => f.debug_tuple("Handshake").finish(),
+        }
+    }
+}
+
+/// A connector combines the futures required to connect to a transport
+/// and then complete the transport's associated startup handshake.
+#[pin_project]
+pub struct Connector<T, P, B>
+where
+    T: Transport,
+    P: Protocol<T::IO, B>,
+    P::Connection: PoolableConnection,
+{
+    #[pin]
+    state: ConnectorState<T, P, B>,
+
+    version: Option<HttpProtocol>,
+    shareable: bool,
+}
+
+impl<T, P, B> fmt::Debug for Connector<T, P, B>
+where
+    T: Transport,
+    P: Protocol<T::IO, B>,
+    P::Connection: PoolableConnection,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Connector")
+            .field("state", &self.state)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T, P, B> Connector<T, P, B>
+where
+    T: Transport,
+    P: Protocol<T::IO, B>,
+    P::Connection: PoolableConnection,
+{
+    /// Create a new connection from a transport connector and a handshake function.
+    pub fn new(
+        transport: T,
+        protocol: P,
+        parts: http::request::Parts,
+        version: HttpProtocol,
+    ) -> Self {
+        //TODO: Fix this
+        let shareable = false;
+
+        Self {
+            state: ConnectorState::PollReadyTransport {
+                parts,
+                transport: Some(transport),
+                protocol: Some(protocol),
+            },
+            version: Some(version),
+            shareable,
+        }
+    }
+}
+
+#[allow(type_alias_bounds)]
+type ConnectionError<T: Transport, P: Protocol<T::IO, B>, B> =
+    Error<<T as Transport>::Error, <P as Protocol<T::IO, B>>::Error>;
+
+impl<T, P, B> Connector<T, P, B>
+where
+    T: Transport,
+    P: Protocol<T::IO, B>,
+    P::Connection: PoolableConnection,
+{
+    pub(in crate::client) fn poll_connector(
+        self: Pin<&mut Self>,
+        pool: &PoolRef<P::Connection>,
+        token: Token,
+        meta: &mut CheckoutMeta,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<P::Connection, ConnectionError<T, P, B>>> {
+        let mut connector_projected = self.project();
+
+        loop {
+            match connector_projected.state.as_mut().project() {
+                ConnectorStateProjected::PollReadyTransport {
+                    parts,
+                    transport,
+                    protocol,
+                } => {
+                    let _entered = meta.transport().enter();
+                    {
+                        let transport = transport.as_mut().unwrap();
+                        if let Err(error) = ready!(transport.poll_ready(cx)) {
+                            return Poll::Ready(Err(Error::Connecting(error)));
+                        }
+                    }
+
+                    let mut transport = transport
+                        .take()
+                        .expect("future polled in invalid state: transport is None");
+                    let future = transport.connect(parts.clone());
+                    let protocol = protocol.take();
+
+                    tracing::trace!("transport ready");
+                    connector_projected
+                        .state
+                        .set(ConnectorState::Connect { future, protocol });
+                }
+
+                ConnectorStateProjected::Connect { future, protocol } => {
+                    let _entered = meta.transport().enter();
+                    let stream = match ready!(future.poll(cx)) {
+                        Ok(stream) => stream,
+                        Err(error) => return Poll::Ready(Err(Error::Connecting(error))),
+                    };
+                    let protocol = protocol.take();
+
+                    tracing::trace!("transport connected");
+                    connector_projected
+                        .state
+                        .set(ConnectorState::PollReadyHandshake {
+                            protocol,
+                            stream: Some(stream),
+                        });
+                }
+
+                ConnectorStateProjected::PollReadyHandshake { protocol, stream } => {
+                    let _entered = meta.protocol().enter();
+
+                    {
+                        let protocol = protocol.as_mut().unwrap();
+                        if let Err(error) =
+                            ready!(<P as Protocol<T::IO, B>>::poll_ready(protocol, cx))
+                        {
+                            return Poll::Ready(Err(Error::Handshaking(error)));
+                        }
+                    }
+
+                    let stream = stream
+                        .take()
+                        .expect("future polled in invalid state: stream is None");
+
+                    let info = stream.info();
+
+                    let future = protocol
+                        .as_mut()
+                        .expect("future polled in invalid state: protocol is None")
+                        .connect(
+                            stream,
+                            connector_projected.version.take().expect("version is None"),
+                        );
+
+                    if *connector_projected.shareable {
+                        // This can happen if we connect expecting an HTTP/1.1 connection, but during the TLS
+                        // handshake we discover that the connection is actually an HTTP/2 connection.
+                        trace!(
+                            ?token,
+                            "connection can be shared, telling pool to wait for handshake"
+                        );
+                        if let Some(mut pool) = pool.lock() {
+                            pool.connected_in_handshake(token);
+                        }
+                    }
+
+                    tracing::trace!("handshake ready");
+
+                    connector_projected
+                        .state
+                        .set(ConnectorState::Handshake { future, info });
+                }
+
+                ConnectorStateProjected::Handshake { future, info } => {
+                    let _entered = meta.protocol().enter();
+
+                    return future.poll(cx).map(|result| match result {
+                        Ok(conn) => {
+                            tracing::debug!("connection to {} ready", info.remote_addr());
+                            Ok(conn)
+                        }
+                        Err(error) => Err(Error::Handshaking(error)),
+                    });
+                }
+            }
+        }
+    }
+}
+
+/// A future that resolves to a connection.
+#[pin_project]
+pub struct ConnectorFuture<T, P, B>
+where
+    T: Transport,
+    P: Protocol<T::IO, B>,
+    P::Connection: PoolableConnection,
+{
+    #[pin]
+    connector: Connector<T, P, B>,
+    pool: PoolRef<P::Connection>,
+    token: Token,
+    meta: CheckoutMeta,
+}
+
+impl<T, P, B> fmt::Debug for ConnectorFuture<T, P, B>
+where
+    T: Transport,
+    P: Protocol<T::IO, B>,
+    P::Connection: PoolableConnection,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("ConnectorFuture")
+            .field(&self.connector)
+            .finish()
+    }
+}
+
+impl<T, P, B> Future for ConnectorFuture<T, P, B>
+where
+    T: Transport,
+    P: Protocol<T::IO, B>,
+    P::Connection: PoolableConnection,
+{
+    type Output = Result<P::Connection, ConnectionError<T, P, B>>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.as_mut().project();
+
+        this.connector
+            .poll_connector(&*this.pool, *this.token, this.meta, cx)
+    }
+}
+
+impl<T, P, B> IntoFuture for Connector<T, P, B>
+where
+    T: Transport,
+    P: Protocol<T::IO, B>,
+    P::Connection: PoolableConnection,
+{
+    type Output = Result<P::Connection, ConnectionError<T, P, B>>;
+    type IntoFuture = ConnectorFuture<T, P, B>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let pool = PoolRef::none();
+        let token = Token::zero();
+        let meta = CheckoutMeta::new();
+
+        ConnectorFuture {
+            connector: self,
+            pool,
+            token,
+            meta,
+        }
+    }
+}

--- a/src/client/conn/mod.rs
+++ b/src/client/conn/mod.rs
@@ -38,12 +38,14 @@
 //! and response objects, and for sending and receiving the data over the transport.
 
 pub mod connection;
+pub mod connector;
 pub mod dns;
 pub mod protocol;
 pub mod stream;
 pub mod transport;
 
 pub use self::connection::Connection;
+pub use self::connector::Connector;
 pub use self::protocol::{Protocol, ProtocolRequest};
 pub use self::stream::Stream;
 pub use self::transport::Transport;

--- a/src/client/conn/protocol/auto.rs
+++ b/src/client/conn/protocol/auto.rs
@@ -19,6 +19,15 @@ use super::HttpProtocol;
 use super::ProtocolRequest;
 
 /// A builder for configuring and starting HTTP connections.
+///
+/// This builder allows configuring the HTTP/1 and HTTP/2 settings for the connection,
+/// and will pick the protocol based on the ALPN negotiation or the request's version
+/// if ALPN is not available.
+///
+/// Since it takes advantage of ALPN, this protocol requires that the underlying IO
+/// implements `HasTlsConnectionInfo` to provide the ALPN negotiation result. This can
+/// be done by calling `TransportExt::with_tls` or `TransportExt::without_tls` on the
+/// transport.
 #[derive(Debug)]
 pub struct HttpConnectionBuilder<B> {
     http1: hyper::client::conn::http1::Builder,

--- a/src/client/conn/protocol/mock.rs
+++ b/src/client/conn/protocol/mock.rs
@@ -8,6 +8,7 @@ use crate::client::conn::connection::ConnectionError;
 use crate::client::conn::stream::mock::{MockStream, StreamID};
 use crate::client::conn::Connection;
 use crate::client::pool::{PoolableConnection, PoolableStream};
+use crate::BoxError;
 
 use super::ProtocolRequest;
 
@@ -81,6 +82,8 @@ impl Connection<crate::Body> for MockSender {
 }
 
 impl PoolableConnection for MockSender {
+    type Error = BoxError;
+
     fn is_open(&self) -> bool {
         self.stream.is_open()
     }
@@ -91,6 +94,13 @@ impl PoolableConnection for MockSender {
 
     fn reuse(&mut self) -> Option<Self> {
         Some(self.clone())
+    }
+
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
     }
 }
 

--- a/src/client/conn/protocol/mock.rs
+++ b/src/client/conn/protocol/mock.rs
@@ -8,7 +8,6 @@ use crate::client::conn::connection::ConnectionError;
 use crate::client::conn::stream::mock::{MockStream, StreamID};
 use crate::client::conn::Connection;
 use crate::client::pool::{PoolableConnection, PoolableStream};
-use crate::BoxError;
 
 use super::ProtocolRequest;
 
@@ -81,9 +80,7 @@ impl Connection<crate::Body> for MockSender {
     }
 }
 
-impl PoolableConnection for MockSender {
-    type Error = BoxError;
-
+impl PoolableConnection<crate::Body> for MockSender {
     fn is_open(&self) -> bool {
         self.stream.is_open()
     }
@@ -94,13 +91,6 @@ impl PoolableConnection for MockSender {
 
     fn reuse(&mut self) -> Option<Self> {
         Some(self.clone())
-    }
-
-    fn poll_ready(
-        &mut self,
-        _cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), Self::Error>> {
-        std::task::Poll::Ready(Ok(()))
     }
 }
 
@@ -146,6 +136,6 @@ mod tests {
 
     use static_assertions::assert_impl_all;
 
-    assert_impl_all!(MockSender: Connection<crate::Body>, PoolableConnection);
+    assert_impl_all!(MockSender: Connection<crate::Body>, PoolableConnection<crate::Body>);
     assert_impl_all!(MockProtocol: Protocol<MockStream, crate::Body>);
 }

--- a/src/client/conn/transport/mock.rs
+++ b/src/client/conn/transport/mock.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 use crate::client::conn::protocol::mock::MockProtocol;
 use crate::client::conn::protocol::HttpProtocol;
 use crate::client::conn::stream::mock::MockStream;
-use crate::client::pool::{self};
+use crate::client::conn::Connector;
 use crate::BoxFuture;
 
 /// An error that can occur when creating a mock transport.
@@ -82,8 +82,8 @@ impl MockTransport {
         self,
         parts: http::request::Parts,
         version: HttpProtocol,
-    ) -> pool::Connector<Self, MockProtocol, crate::Body> {
-        pool::Connector::new(self, MockProtocol::default(), parts, version)
+    ) -> Connector<Self, MockProtocol, crate::Body> {
+        Connector::new(self, MockProtocol::default(), parts, version)
     }
 }
 

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use super::pool;
+use super::conn::connector::Error as ConnectorError;
 use crate::BoxError;
 
 /// Client error type.
@@ -40,16 +40,16 @@ pub enum Error {
     RequestTimeout,
 }
 
-impl<E1, E2> From<pool::Error<E1, E2>> for Error
+impl<E1, E2> From<ConnectorError<E1, E2>> for Error
 where
     E1: Into<BoxError>,
     E2: Into<BoxError>,
 {
-    fn from(error: pool::Error<E1, E2>) -> Self {
+    fn from(error: ConnectorError<E1, E2>) -> Self {
         match error {
-            pool::Error::Connecting(error) => Error::Connection(error.into()),
-            pool::Error::Handshaking(error) => Error::Transport(error.into()),
-            pool::Error::Unavailable => {
+            ConnectorError::Connecting(error) => Error::Connection(error.into()),
+            ConnectorError::Handshaking(error) => Error::Transport(error.into()),
+            ConnectorError::Unavailable => {
                 Error::Connection("pool closed, no connection can be made".into())
             }
         }

--- a/src/client/pool/checkout.rs
+++ b/src/client/pool/checkout.rs
@@ -8,16 +8,14 @@ use std::task::Poll;
 
 use pin_project::pin_project;
 use pin_project::pinned_drop;
-use thiserror::Error;
 use tokio::sync::oneshot::Receiver;
 use tracing::debug;
 use tracing::trace;
 
-use crate::client::conn::protocol::HttpProtocol;
+use crate::client::conn::connector::Error as ConnectorError;
+use crate::client::conn::connector::{CheckoutMeta, Connector};
 use crate::client::conn::Protocol;
 use crate::client::conn::Transport;
-use crate::info::ConnectionInfo;
-use crate::info::HasConnectionInfo;
 
 use super::key::Token;
 use super::Config;
@@ -44,19 +42,6 @@ impl fmt::Display for CheckoutId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "checkout-{}", self.0)
     }
-}
-
-#[derive(Debug, Error, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum Error<Transport, Protocol> {
-    #[error("creating connection")]
-    Connecting(#[source] Transport),
-
-    #[error("handshaking connection")]
-    Handshaking(#[source] Protocol),
-
-    #[error("connection closed")]
-    Unavailable,
 }
 
 #[pin_project(project = WaitingProjected)]
@@ -126,236 +111,6 @@ impl<C: PoolableConnection> Future for Waiting<C> {
     }
 }
 
-#[pin_project(project = ConnectorStateProjected)]
-enum ConnectorState<T, P, B>
-where
-    T: Transport,
-    P: Protocol<T::IO, B>,
-    P::Connection: PoolableConnection,
-{
-    PollReadyTransport {
-        parts: http::request::Parts,
-        transport: Option<T>,
-        protocol: Option<P>,
-    },
-    Connect {
-        #[pin]
-        future: T::Future,
-        protocol: Option<P>,
-    },
-    PollReadyHandshake {
-        protocol: Option<P>,
-        stream: Option<T::IO>,
-    },
-    Handshake {
-        #[pin]
-        future: <P as Protocol<T::IO, B>>::Future,
-        info: ConnectionInfo<<T::IO as HasConnectionInfo>::Addr>,
-    },
-}
-
-impl<T, P, B> fmt::Debug for ConnectorState<T, P, B>
-where
-    T: Transport,
-    P: Protocol<T::IO, B>,
-    P::Connection: PoolableConnection,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ConnectorState::PollReadyTransport { parts, .. } => f
-                .debug_struct("PollReadyTransport")
-                .field("address", &parts.uri)
-                .finish(),
-            ConnectorState::Connect { .. } => f.debug_tuple("Connect").finish(),
-            ConnectorState::PollReadyHandshake { .. } => {
-                f.debug_tuple("PollReadyHandshake").finish()
-            }
-            ConnectorState::Handshake { .. } => f.debug_tuple("Handshake").finish(),
-        }
-    }
-}
-
-/// A connector combines the futures required to connect to a transport
-/// and then complete the transport's associated startup handshake.
-#[pin_project]
-pub struct Connector<T, P, B>
-where
-    T: Transport,
-    P: Protocol<T::IO, B>,
-    P::Connection: PoolableConnection,
-{
-    #[pin]
-    state: ConnectorState<T, P, B>,
-
-    version: Option<HttpProtocol>,
-    shareable: bool,
-}
-
-impl<T, P, B> fmt::Debug for Connector<T, P, B>
-where
-    T: Transport,
-    P: Protocol<T::IO, B>,
-    P::Connection: PoolableConnection,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Connector")
-            .field("state", &self.state)
-            .finish_non_exhaustive()
-    }
-}
-
-impl<T, P, B> Connector<T, P, B>
-where
-    T: Transport,
-    P: Protocol<T::IO, B>,
-    P::Connection: PoolableConnection,
-{
-    /// Create a new connection from a transport connector and a handshake function.
-    pub fn new(
-        transport: T,
-        protocol: P,
-        parts: http::request::Parts,
-        version: HttpProtocol,
-    ) -> Self {
-        //TODO: Fix this
-        let shareable = false;
-
-        Self {
-            state: ConnectorState::PollReadyTransport {
-                parts,
-                transport: Some(transport),
-                protocol: Some(protocol),
-            },
-            version: Some(version),
-            shareable,
-        }
-    }
-}
-
-#[allow(type_alias_bounds)]
-type ConnectionError<T: Transport, P: Protocol<T::IO, B>, B> =
-    Error<<T as Transport>::Error, <P as Protocol<T::IO, B>>::Error>;
-
-impl<T, P, B> Connector<T, P, B>
-where
-    T: Transport,
-    P: Protocol<T::IO, B>,
-    P::Connection: PoolableConnection,
-{
-    fn poll_connector(
-        self: Pin<&mut Self>,
-        pool: &PoolRef<P::Connection>,
-        token: Token,
-        meta: &mut CheckoutMeta,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<P::Connection, ConnectionError<T, P, B>>> {
-        let mut connector_projected = self.project();
-
-        loop {
-            match connector_projected.state.as_mut().project() {
-                ConnectorStateProjected::PollReadyTransport {
-                    parts,
-                    transport,
-                    protocol,
-                } => {
-                    let _entered = meta.transport().enter();
-                    {
-                        let transport = transport.as_mut().unwrap();
-                        if let Err(error) = ready!(transport.poll_ready(cx)) {
-                            return Poll::Ready(Err(Error::Connecting(error)));
-                        }
-                    }
-
-                    let mut transport = transport
-                        .take()
-                        .expect("future polled in invalid state: transport is None");
-                    let future = transport.connect(parts.clone());
-                    let protocol = protocol.take();
-
-                    tracing::trace!("transport ready");
-                    connector_projected
-                        .state
-                        .set(ConnectorState::Connect { future, protocol });
-                }
-
-                ConnectorStateProjected::Connect { future, protocol } => {
-                    let _entered = meta.transport().enter();
-                    let stream = match ready!(future.poll(cx)) {
-                        Ok(stream) => stream,
-                        Err(error) => return Poll::Ready(Err(Error::Connecting(error))),
-                    };
-                    let protocol = protocol.take();
-
-                    tracing::trace!("transport connected");
-                    connector_projected
-                        .state
-                        .set(ConnectorState::PollReadyHandshake {
-                            protocol,
-                            stream: Some(stream),
-                        });
-                }
-
-                ConnectorStateProjected::PollReadyHandshake { protocol, stream } => {
-                    let _entered = meta.protocol().enter();
-
-                    {
-                        let protocol = protocol.as_mut().unwrap();
-                        if let Err(error) =
-                            ready!(<P as Protocol<T::IO, B>>::poll_ready(protocol, cx))
-                        {
-                            return Poll::Ready(Err(Error::Handshaking(error)));
-                        }
-                    }
-
-                    let stream = stream
-                        .take()
-                        .expect("future polled in invalid state: stream is None");
-
-                    let info = stream.info();
-
-                    let future = protocol
-                        .as_mut()
-                        .expect("future polled in invalid state: protocol is None")
-                        .connect(
-                            stream,
-                            connector_projected.version.take().expect("version is None"),
-                        );
-
-                    if *connector_projected.shareable {
-                        // This can happen if we connect expecting an HTTP/1.1 connection, but during the TLS
-                        // handshake we discover that the connection is actually an HTTP/2 connection.
-                        trace!(
-                            ?token,
-                            "connection can be shared, telling pool to wait for handshake"
-                        );
-                        if let Some(mut pool) = pool.lock() {
-                            pool.connected_in_handshake(token);
-                        }
-                    }
-
-                    tracing::trace!("handshake ready");
-
-                    connector_projected
-                        .state
-                        .set(ConnectorState::Handshake { future, info });
-                }
-
-                ConnectorStateProjected::Handshake { future, info } => {
-                    let _entered = meta.protocol().enter();
-
-                    return future.poll(cx).map(|result| match result {
-                        Ok(conn) => {
-                            tracing::debug!("connection to {} ready", info.remote_addr());
-                            Ok(conn)
-                        }
-                        Err(error) => Err(Error::Handshaking(error)),
-                    });
-                }
-            }
-        }
-    }
-}
-
 #[pin_project(project = CheckoutConnectingProj)]
 pub(crate) enum InnerCheckoutConnecting<T, P, B>
 where
@@ -391,34 +146,6 @@ where
                 f.debug_tuple("ConnectingDelayed").field(connector).finish()
             }
         }
-    }
-}
-
-struct CheckoutMeta {
-    overall_span: tracing::Span,
-    transport_span: Option<tracing::Span>,
-    protocol_span: Option<tracing::Span>,
-}
-
-impl CheckoutMeta {
-    fn new() -> Self {
-        let overall_span = tracing::Span::current();
-
-        Self {
-            overall_span,
-            transport_span: None,
-            protocol_span: None,
-        }
-    }
-
-    fn transport(&mut self) -> &tracing::Span {
-        self.transport_span
-            .get_or_insert_with(|| tracing::trace_span!(parent: &self.overall_span, "transport"))
-    }
-
-    fn protocol(&mut self) -> &tracing::Span {
-        self.protocol_span
-            .get_or_insert_with(|| tracing::trace_span!(parent: &self.overall_span, "protocol"))
     }
 }
 
@@ -593,12 +320,12 @@ where
 {
     type Output = Result<
         Pooled<P::Connection>,
-        Error<<T as Transport>::Error, <P as Protocol<T::IO, B>>::Error>,
+        ConnectorError<<T as Transport>::Error, <P as Protocol<T::IO, B>>::Error>,
     >;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut this = self.as_mut().project();
-        let _entered = this.meta.overall_span.clone().entered();
+        let _entered = this.meta.current().clone().entered();
 
         {
             // Outcomes from .poll_waiter:
@@ -624,7 +351,7 @@ where
                 // We're waiting on a connection to be ready.
                 // If that were still happening, we would bail out above, since the waiter
                 // would return Poll::Pending.
-                Poll::Ready(Err(Error::Unavailable))
+                Poll::Ready(Err(ConnectorError::Unavailable))
             }
             CheckoutConnectingProj::Connected => {
                 // We've already connected, we can just return the connection.
@@ -745,8 +472,9 @@ mod test {
 
     use static_assertions::assert_impl_all;
 
-    assert_impl_all!(Error<std::io::Error, std::io::Error>: std::error::Error, Send, Sync, Into<BoxError>);
+    assert_impl_all!(ConnectorError<std::io::Error, std::io::Error>: std::error::Error, Send, Sync, Into<BoxError>);
 
+    use crate::client::conn::protocol::HttpProtocol;
     #[cfg(feature = "mocks")]
     use crate::client::conn::transport::mock::MockTransport;
     use crate::BoxError;

--- a/src/client/pool/service.rs
+++ b/src/client/pool/service.rs
@@ -19,6 +19,7 @@ use crate::client::pool;
 use crate::client::pool::Checkout;
 use crate::client::pool::Connector;
 use crate::client::pool::PoolableConnection;
+use crate::client::pool::Pooled;
 use crate::client::Error;
 use crate::info::HasConnectionInfo;
 use crate::service::client::ExecuteRequest;
@@ -255,7 +256,7 @@ where
     T: Transport + Send + 'static,
     T::IO: PoolableStream + Unpin,
     <<T as Transport>::IO as HasConnectionInfo>::Addr: Send,
-    S: tower::Service<ExecuteRequest<C, BIn>, Response = http::Response<BOut>>
+    S: tower::Service<ExecuteRequest<Pooled<C>, BIn>, Response = http::Response<BOut>>
         + Clone
         + Send
         + 'static,
@@ -298,7 +299,7 @@ where
         + 'static,
     T: Transport + 'static,
     T::IO: PoolableStream + Unpin,
-    S: tower::Service<ExecuteRequest<C, BIn>, Response = http::Response<BOut>>
+    S: tower::Service<ExecuteRequest<Pooled<C>, BIn>, Response = http::Response<BOut>>
         + Clone
         + Send
         + 'static,
@@ -323,7 +324,9 @@ where
     T: Transport + Send + 'static,
     P: Protocol<T::IO, BIn, Connection = C> + Send + 'static,
     C: Connection<BIn> + PoolableConnection,
-    S: tower::Service<ExecuteRequest<C, BIn>, Response = http::Response<BOut>> + Send + 'static,
+    S: tower::Service<ExecuteRequest<Pooled<C>, BIn>, Response = http::Response<BOut>>
+        + Send
+        + 'static,
     BIn: 'static,
 {
     #[pin]
@@ -336,7 +339,9 @@ where
     T: Transport + Send + 'static,
     P: Protocol<T::IO, BIn, Connection = C> + Send + 'static,
     C: Connection<BIn> + PoolableConnection,
-    S: tower::Service<ExecuteRequest<C, BIn>, Response = http::Response<BOut>> + Send + 'static,
+    S: tower::Service<ExecuteRequest<Pooled<C>, BIn>, Response = http::Response<BOut>>
+        + Send
+        + 'static,
     BIn: 'static,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -349,7 +354,9 @@ where
     T: Transport + Send + 'static,
     P: Protocol<T::IO, BIn, Connection = C> + Send + 'static,
     C: Connection<BIn> + PoolableConnection,
-    S: tower::Service<ExecuteRequest<C, BIn>, Response = http::Response<BOut>> + Send + 'static,
+    S: tower::Service<ExecuteRequest<Pooled<C>, BIn>, Response = http::Response<BOut>>
+        + Send
+        + 'static,
     BIn: 'static,
 {
     fn new(checkout: Checkout<T, P, BIn>, request: http::Request<BIn>, service: S) -> Self {
@@ -378,7 +385,9 @@ where
     P: Protocol<T::IO, BIn, Connection = C> + Send + 'static,
     <P as Protocol<T::IO, BIn>>::Error: Into<BoxError>,
     C: Connection<BIn> + PoolableConnection,
-    S: tower::Service<ExecuteRequest<C, BIn>, Response = http::Response<BOut>> + Send + 'static,
+    S: tower::Service<ExecuteRequest<Pooled<C>, BIn>, Response = http::Response<BOut>>
+        + Send
+        + 'static,
     S::Error: Into<crate::client::Error>,
     BOut: Body + Unpin + 'static,
     BIn: Body + Unpin + Send + 'static,
@@ -437,7 +446,9 @@ where
     T: Transport + Send + 'static,
     P: Protocol<T::IO, BIn, Connection = C> + Send + 'static,
     C: Connection<BIn> + PoolableConnection,
-    S: tower::Service<ExecuteRequest<C, BIn>, Response = http::Response<BOut>> + Send + 'static,
+    S: tower::Service<ExecuteRequest<Pooled<C>, BIn>, Response = http::Response<BOut>>
+        + Send
+        + 'static,
     BIn: 'static,
 {
     Checkout {

--- a/src/service/host.rs
+++ b/src/service/host.rs
@@ -5,7 +5,6 @@ use http::HeaderValue;
 use http::Uri;
 
 use crate::client::conn::Connection;
-use crate::client::pool::PoolableConnection;
 
 use super::ExecuteRequest;
 
@@ -94,7 +93,7 @@ where
 impl<S, B, C> tower::Service<ExecuteRequest<C, B>> for SetHostHeader<S>
 where
     S: tower::Service<ExecuteRequest<C, B>>,
-    C: Connection<B> + PoolableConnection,
+    C: Connection<B>,
 {
     type Response = S::Response;
 

--- a/src/service/http.rs
+++ b/src/service/http.rs
@@ -59,7 +59,6 @@ pub(super) mod http1 {
     use http::Uri;
 
     use crate::client::conn::Connection;
-    use crate::client::pool::PoolableConnection;
     use crate::client::Error;
     use crate::service::client::ExecuteRequest;
     use crate::service::error::MaybeErrorFuture;
@@ -72,7 +71,7 @@ pub(super) mod http1 {
     pub struct Http1ChecksService<S, C, B>
     where
         S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
-        C: Connection<B> + PoolableConnection,
+        C: Connection<B>,
     {
         inner: PreprocessService<S, PreprocessFn<C, B, S::Error>>,
     }
@@ -80,7 +79,7 @@ pub(super) mod http1 {
     impl<S, C, B> tower::Service<ExecuteRequest<C, B>> for Http1ChecksService<S, C, B>
     where
         S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
-        C: Connection<B> + PoolableConnection,
+        C: Connection<B>,
     {
         type Response = S::Response;
 
@@ -100,7 +99,7 @@ pub(super) mod http1 {
     impl<S, C, B> Clone for Http1ChecksService<S, C, B>
     where
         S: tower::Service<ExecuteRequest<C, B>, Error = Error> + Clone,
-        C: Connection<B> + PoolableConnection,
+        C: Connection<B>,
     {
         fn clone(&self) -> Self {
             Self {
@@ -112,7 +111,7 @@ pub(super) mod http1 {
     impl<S, C, B> Http1ChecksService<S, C, B>
     where
         S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
-        C: Connection<B> + PoolableConnection,
+        C: Connection<B>,
     {
         /// Create a new `Http1ChecksService`.
         pub fn new(service: S) -> Self {
@@ -157,7 +156,7 @@ pub(super) mod http1 {
     impl<C, B, S> tower::layer::Layer<S> for Http1ChecksLayer<C, B>
     where
         S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
-        C: Connection<B> + PoolableConnection,
+        C: Connection<B>,
     {
         type Service = Http1ChecksService<S, C, B>;
 
@@ -170,7 +169,7 @@ pub(super) mod http1 {
         mut req: ExecuteRequest<C, B>,
     ) -> Result<ExecuteRequest<C, B>, Error>
     where
-        C: Connection<B> + PoolableConnection,
+        C: Connection<B>,
     {
         if req.connection().version() >= http::Version::HTTP_2 {
             return Ok(req);
@@ -303,7 +302,6 @@ pub(super) mod http2 {
     use ::http;
 
     use crate::client::conn::Connection;
-    use crate::client::pool::PoolableConnection;
     use crate::client::Error;
     use crate::service::client::ExecuteRequest;
     use crate::service::error::{MaybeErrorFuture, PreprocessService};
@@ -323,7 +321,7 @@ pub(super) mod http2 {
     pub struct Http2ChecksService<S, C, B>
     where
         S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
-        C: Connection<B> + PoolableConnection,
+        C: Connection<B>,
     {
         inner: PreprocessService<S, PreprocessFn<C, B, S::Error>>,
     }
@@ -331,7 +329,7 @@ pub(super) mod http2 {
     impl<S, C, B> Clone for Http2ChecksService<S, C, B>
     where
         S: tower::Service<ExecuteRequest<C, B>, Error = Error> + Clone,
-        C: Connection<B> + PoolableConnection,
+        C: Connection<B>,
     {
         fn clone(&self) -> Self {
             Self::new(self.inner.service().clone())
@@ -341,7 +339,7 @@ pub(super) mod http2 {
     impl<S, C, B> Http2ChecksService<S, C, B>
     where
         S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
-        C: Connection<B> + PoolableConnection,
+        C: Connection<B>,
     {
         /// Create a new `Http2ChecksService`.
         pub fn new(inner: S) -> Self {
@@ -355,7 +353,7 @@ pub(super) mod http2 {
         mut req: ExecuteRequest<C, B>,
     ) -> Result<ExecuteRequest<C, B>, Error>
     where
-        C: Connection<B> + PoolableConnection,
+        C: Connection<B>,
     {
         if req.connection().version() == http::Version::HTTP_2 {
             if req.request().method() == http::Method::CONNECT {
@@ -393,7 +391,7 @@ pub(super) mod http2 {
     impl<S, C, B> tower::Service<ExecuteRequest<C, B>> for Http2ChecksService<S, C, B>
     where
         S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
-        C: Connection<B> + PoolableConnection,
+        C: Connection<B>,
     {
         type Response = S::Response;
 
@@ -447,7 +445,7 @@ pub(super) mod http2 {
     impl<S, C, B> tower::layer::Layer<S> for Http2ChecksLayer<C, B>
     where
         S: tower::Service<ExecuteRequest<C, B>, Error = Error>,
-        C: Connection<B> + PoolableConnection,
+        C: Connection<B>,
     {
         type Service = Http2ChecksService<S, C, B>;
 

--- a/tests/client/connector.rs
+++ b/tests/client/connector.rs
@@ -1,0 +1,105 @@
+//! Test hyperdriver client using low-level connector.
+use futures_util::StreamExt;
+use http::StatusCode;
+use hyperdriver::bridge::io::TokioIo;
+use hyperdriver::client::conn::connector::ConnectorLayer;
+use hyperdriver::client::conn::Connection as _;
+use hyperdriver::service::RequestExecutor;
+use hyperdriver::Body;
+use std::pin::pin;
+use tower::ServiceExt;
+
+use hyperdriver::client::conn::protocol::http1::Builder as HttpConnectionBuilder;
+use hyperdriver::client::conn::transport::duplex::DuplexTransport;
+type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+#[tokio::test]
+async fn client() -> Result<(), BoxError> {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let (tx, incoming) = hyperdriver::stream::duplex::pair();
+
+    let acceptor: hyperdriver::server::conn::Acceptor =
+        hyperdriver::server::conn::Acceptor::from(incoming);
+
+    let server = tokio::spawn(serve_one_h1(acceptor));
+
+    let client = tower::ServiceBuilder::new()
+        .layer(ConnectorLayer::new(
+            DuplexTransport::new(1024, tx.clone()),
+            HttpConnectionBuilder::new(),
+        ))
+        .service(RequestExecutor::new());
+
+    let req = http::Request::get("http://test/").body(Body::empty())?;
+
+    let resp: http::Response<Body> = client.oneshot(req).await?.map(Into::into);
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    server.abort();
+    let _ = server.await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn connector() -> Result<(), BoxError> {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let (tx, incoming) = hyperdriver::stream::duplex::pair();
+
+    let acceptor: hyperdriver::server::conn::Acceptor =
+        hyperdriver::server::conn::Acceptor::from(incoming);
+
+    let server = tokio::spawn(serve_one_h1(acceptor));
+
+    let req = http::Request::get("http://test/").body(Body::empty())?;
+    let (parts, body) = req.into_parts();
+
+    let connector = hyperdriver::client::conn::Connector::new(
+        DuplexTransport::new(1024, tx.clone()),
+        HttpConnectionBuilder::new(),
+        parts.clone(),
+        http::Version::HTTP_11.into(),
+    );
+
+    let mut conn = connector.await?;
+    let resp = conn
+        .send_request(http::Request::from_parts(parts, body))
+        .await?;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    server.abort();
+    let _ = server.await;
+
+    Ok(())
+}
+
+async fn service_ok(
+    req: http::Request<hyper::body::Incoming>,
+) -> Result<http::Response<hyperdriver::Body>, BoxError> {
+    Ok(http::response::Builder::new()
+        .status(200)
+        .header(
+            "O-Host",
+            req.headers()
+                .get("Host")
+                .and_then(|h| h.to_str().ok())
+                .unwrap_or("missing"),
+        )
+        .body(hyperdriver::body::Body::empty())?)
+}
+
+async fn serve_one_h1(acceptor: hyperdriver::server::conn::Acceptor) -> Result<(), BoxError> {
+    let mut acceptor = pin!(acceptor);
+    let stream = acceptor.next().await.ok_or("no connection")??;
+
+    let service = hyper::service::service_fn(service_ok);
+
+    let conn =
+        hyper::server::conn::http1::Builder::new().serve_connection(TokioIo::new(stream), service);
+
+    conn.await?;
+
+    Ok(())
+}


### PR DESCRIPTION
The client connector separates the job of using a transport and protocol to connect to a server from using a connection pool. Originally, although the pool could be disabled, the service always assumed that a pool was present and that connections were inherently poolable.

This new design exposes the Connector directly, so that connections which aren't (or shouldn't be) poolable can be used.

It also allows direct access to the Connector for cases where only a single connection is required, and the ceremony of creating an entire tower Service to handle a single request is unnecessary.
