### PR TITLE
feat: Transport trait is dyn-compatible

### DIFF
--- a/examples/single_threaded.rs
+++ b/examples/single_threaded.rs
@@ -29,7 +29,6 @@ use hyperdriver::info::HasConnectionInfo;
 use hyperdriver::server::Accept;
 use hyperdriver::service::{make_service_fn, RequestExecutor};
 use hyperdriver::stream::TcpStream;
-use hyperdriver::IntoRequestParts;
 use pin_project::pin_project;
 use tokio::io::{self, AsyncWriteExt};
 use tokio::net::TcpListener;
@@ -392,8 +391,8 @@ impl Transport for TransportNotSend {
 
     type Future = Pin<Box<dyn Future<Output = Result<Self::IO, Self::Error>> + Send>>;
 
-    fn connect<R: IntoRequestParts>(&mut self, req: R) -> <Self as Transport>::Future {
-        self.tcp.connect(req.into_request_parts()).boxed()
+    fn connect(&mut self, req: http::request::Parts) -> <Self as Transport>::Future {
+        self.tcp.connect(req).boxed()
     }
 
     fn poll_ready(

--- a/src/client/conn/connector.rs
+++ b/src/client/conn/connector.rs
@@ -422,7 +422,7 @@ where
         + Send
         + Sync
         + 'static,
-    T: Transport + Send + 'static,
+    T: Transport + Clone + Send + 'static,
     T::IO: Unpin,
     <<T as Transport>::IO as HasConnectionInfo>::Addr: Send,
     S: tower::Service<ExecuteRequest<C, BIn>, Response = http::Response<BOut>>

--- a/src/client/pool/service.rs
+++ b/src/client/pool/service.rs
@@ -219,7 +219,7 @@ where
 
 impl<T, P, S, BIn, K> ConnectionPoolService<T, P, S, BIn, K>
 where
-    T: Transport,
+    T: Transport + Clone,
     T::IO: Unpin,
     P: Protocol<T::IO, BIn, Error = ConnectionError> + Clone + Send + Sync + 'static,
     <P as Protocol<T::IO, BIn>>::Connection: PoolableConnection<BIn> + Send + 'static,
@@ -258,7 +258,7 @@ where
         + Send
         + Sync
         + 'static,
-    T: Transport + Send + 'static,
+    T: Transport + Clone + Send + 'static,
     T::IO: PoolableStream + Unpin,
     <<T as Transport>::IO as HasConnectionInfo>::Addr: Send,
     S: tower::Service<ExecuteRequest<Pooled<C, BIn>, BIn>, Response = http::Response<BOut>>
@@ -302,7 +302,7 @@ where
         + Send
         + Sync
         + 'static,
-    T: Transport + 'static,
+    T: Transport + Clone + 'static,
     T::IO: PoolableStream + Unpin,
     S: tower::Service<ExecuteRequest<Pooled<C, BIn>, BIn>, Response = http::Response<BOut>>
         + Clone


### PR DESCRIPTION
Removed Clone as a super-trait, and move the generic connect<R> method to the extension trait as connect_with, since it was just a convenience to allow the use of IntoRequestParts
