### PR TITLE
Chore: Clippy

### DIFF
--- a/src/client/conn/mod.rs
+++ b/src/client/conn/mod.rs
@@ -11,9 +11,9 @@
 //!
 //! Two builtin transports are provided:
 //! - [`transport::tcp::TcpTransport`]: Connects to a remote server over TCP/IP. This is the default transport, and what
-//!     usually powers HTTP connections.
+//!   usually powers HTTP connections.
 //! - [`transport::duplex::DuplexTransport`]: Connects to a remote server over a duplex stream, which
-//!     is an in-memory stream that can be used for testing or other purposes.
+//!   is an in-memory stream that can be used for testing or other purposes.
 //!
 //! ## Stream
 //!

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -113,7 +113,7 @@ pub trait Protocol<S, IO, B> {
 ///   connection stream (to facilitate connection information).
 /// - `B` is the body type for the service.
 /// - `E` is the executor to use for running the server. This is used to spawn the
-///    connection futures.
+///   connection futures.
 pub struct Server<A, P, S, B, E> {
     acceptor: A,
     protocol: P,

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -77,7 +77,7 @@ where
     async move {
         tracing::trace!("sending shutdown signal");
         let _ = tx.send(());
-        handle.await.unwrap().map_err(Into::into)
+        handle.await.unwrap()
     }
 }
 


### PR DESCRIPTION
- **clippy: fix redundant call to Into::into**
- **clippy: fix list indents in doc comments**
