### PR TITLE
Remove TLS span from full service call, scope it only to recieving the

### DIFF
--- a/src/server/conn/tls/info.rs
+++ b/src/server/conn/tls/info.rs
@@ -167,9 +167,9 @@ where
                     req.extensions_mut().insert(info);
                 }
             }
-            .instrument(span.clone())
+            .instrument(span)
             .await;
-            inner.call(req).instrument(span).await
+            inner.call(req).await
         };
 
         Box::pin(fut)


### PR DESCRIPTION
TLS connection information.